### PR TITLE
Parses the term_id as an integer in Elastic_Press class

### DIFF
--- a/src/classes/class-tainacan-elastic-press.php
+++ b/src/classes/class-tainacan-elastic-press.php
@@ -649,7 +649,7 @@ class Elastic_Press {
 				$taxonomy_slug = $description_types[2];
 				$taxonomy_id = Repositories\Taxonomies::get_instance()->get_id_by_db_identifier($taxonomy_slug);
 				foreach ($aggregation[$key]['buckets'] as $term) {
-					$term_id = $term['key'];
+					$term_id = intval($term['key']);
 					$term_object = \Tainacan\Repositories\Terms::get_instance()->fetch($term_id, $taxonomy_slug);
 					$count_query = $wpdb->prepare("SELECT COUNT(term_id) FROM $wpdb->term_taxonomy WHERE parent = %d", $term_id);
 					$total_children = $wpdb->get_var($count_query);

--- a/src/classes/class-tainacan-elastic-press.php
+++ b/src/classes/class-tainacan-elastic-press.php
@@ -727,13 +727,13 @@ class Elastic_Press {
 				$buckets = ($has_include == false ? $aggregation['buckets'] : $aggregation[$key]['buckets']);
 				foreach ($buckets as $term) {
 					if ($has_include) {
-						$term_id = $term['key'];
+						$term_id = intval($term['key']);
 						$doc_count = $term['doc_count'];
 					} else {
-						$term_id = $term['key'][$key];
+						$term_id = intval($term['key'][$key]);
 						$doc_count = $term['doc_count'];
 					}
-					if ($term_id == '') continue;
+					if ($term_id === 0) continue;
 
 					$term_object = \Tainacan\Repositories\Terms::get_instance()->fetch($term_id, $taxonomy_slug);
 					$count_query = $wpdb->prepare("SELECT COUNT(term_id) FROM $wpdb->term_taxonomy WHERE parent = %d", $term_id);


### PR DESCRIPTION
Sometimes the $term['key'] value is a numeric string, causing
the method Tainacan\Repositories\Terms::fetch to return an array and, 
consequently, a fatal error.