### PR TITLE
Add dependencies caps in roles API

### DIFF
--- a/src/classes/api/endpoints/class-tainacan-rest-roles-controller.php
+++ b/src/classes/api/endpoints/class-tainacan-rest-roles-controller.php
@@ -294,6 +294,7 @@ class REST_Roles_Controller extends REST_Controller {
 
 		foreach ( $newcaps as $cap => $val ) {
 			\wp_roles()->add_cap($role_slug, $cap, $val);
+			\tainacan_roles()->add_dependencies($role_slug, $cap);
 		}
 
 

--- a/src/classes/class-tainacan-roles.php
+++ b/src/classes/class-tainacan-roles.php
@@ -5,16 +5,6 @@ use Tainacan\Repositories\Repository;
 
 class Roles {
 
-
-	public static $dependencies = [
-		"tainacan-items" => [
-			'edit_posts'           => 'upload_files',
-			"edit_private_posts"   => 'upload_files',
-			"edit_published_posts" => 'upload_files',
-			"edit_others_posts"    => 'upload_files'
-		]
-	];
-
 	private static $instance = null;
 
 	private $capabilities;

--- a/tests/test-api-roles.php
+++ b/tests/test-api-roles.php
@@ -234,6 +234,38 @@ class TAINACAN_REST_Roles_Controller extends TAINACAN_UnitApiTestCase {
 		$this->assertTrue($role['capabilities']['upload_files']);
 	}
 
+	public function test_add_dependencies_capabilities() {
+		$request = new \WP_REST_Request('POST', $this->namespace . '/roles');
+
+		$request->set_query_params(['name' => 'New role']);
+
+		$create = $this->server->dispatch($request);
+		//var_dump($create);
+		$this->assertEquals( 201, $create->get_status() );
+
+		$request = new \WP_REST_Request('PATCH', $this->namespace . '/roles/tainacan-new-role');
+
+		$request->set_query_params(
+			[
+				'name' => 'Changed name',
+				'capabilities' => [
+					'tnc_col_12_edit_items' => true
+				]
+			]
+		);
+
+		$response = $this->server->dispatch($request);
+
+		$this->assertEquals( 200, $response->get_status() );
+
+		$role = \wp_roles()->roles['tainacan-new-role'];
+
+		$this->assertArrayHasKey('tnc_col_12_edit_items', $role['capabilities']);
+		$this->assertTrue($role['capabilities']['tnc_col_12_edit_items']);
+		$this->assertArrayHasKey('upload_files', $role['capabilities']);
+		$this->assertTrue($role['capabilities']['upload_files']);
+	}
+
 	public function test_get_collection_caps() {
 
 		$collection = $this->tainacan_entity_factory->create_entity(


### PR DESCRIPTION
Adds dependencies capabilities when calling the roles api with the `capabilities` parameter.

It was only adding dependencies when calling with `add_cap` parameter.

Testing:

Create a new role. Add "edit_collections" capability to that role. Check that `upload_files` was also added to the role.