### PR TITLE
Improves output and log feedback in the background process

### DIFF
--- a/src/classes/exporter/class-tainacan-csv.php
+++ b/src/classes/exporter/class-tainacan-csv.php
@@ -5,25 +5,25 @@ use Tainacan;
 use Tainacan\Entities;
 
 class CSV extends Exporter {
-  private $collection_name;
+	private $collection_name;
 
 	public function __construct($attributes = array()) {
 		parent::__construct($attributes);
 		$this->set_accepted_mapping_methods('any'); // set all method to mapping
 		$this->accept_no_mapping = true;
 		if ($current_collection = $this->get_current_collection_object()) {
-        $name = $current_collection->get_name();
-        $this->collection_name = sanitize_title($name) . "_csv_export.csv";;
-    } else {
-		  $this->collection_name = "csv_export.csv";
-    }
+			$name = $current_collection->get_name();
+			$this->collection_name = sanitize_title($name) . "_csv_export.csv";;
+		} else {
+			$this->collection_name = "csv_export.csv";
+		}
 
 		//$this->set_accepted_mapping_methods('list', [ "dublin-core" ]); // set specific list of methods to mapping
 		$this->set_default_options([
-            'delimiter' => ',',
-            'multivalued_delimiter' => '||',
-            'enclosure' => '"'
-        ]);
+			'delimiter' => ',',
+			'multivalued_delimiter' => '||',
+			'enclosure' => '"'
+		]);
 	}
 	
 	public function filter_multivalue_separator($separator) {
@@ -278,7 +278,7 @@ class CSV extends Exporter {
 
 	public function options_form() {
 		ob_start();
-	   ?>
+		?>
 		<div class="field">
 			<label class="label"><?php _e('CSV Delimiter', 'tainacan'); ?></label>
 			<span class="help-wrapper">
@@ -346,11 +346,7 @@ class CSV extends Exporter {
 		</div>
 		
 		
-	   
-	   <?php 
-	   
-	   
-	   return ob_get_clean();
-
-    }
+		<?php
+		return ob_get_clean();
+	}
 }

--- a/src/classes/exporter/class-tainacan-csv.php
+++ b/src/classes/exporter/class-tainacan-csv.php
@@ -5,11 +5,19 @@ use Tainacan;
 use Tainacan\Entities;
 
 class CSV extends Exporter {
+  private $collection_name;
 
 	public function __construct($attributes = array()) {
 		parent::__construct($attributes);
 		$this->set_accepted_mapping_methods('any'); // set all method to mapping
 		$this->accept_no_mapping = true;
+		if ($current_collection = $this->get_current_collection_object()) {
+        $name = $current_collection->get_name();
+        $this->collection_name = sanitize_title($name) . "_csv_export.csv";;
+    } else {
+		  $this->collection_name = "csv_export.csv";
+    }
+
 		//$this->set_accepted_mapping_methods('list', [ "dublin-core" ]); // set specific list of methods to mapping
 		$this->set_default_options([
             'delimiter' => ',',
@@ -79,10 +87,8 @@ class CSV extends Exporter {
 		$line[] = $item->get_modification_date();
 		
 		$line_string = $this->str_putcsv($line, $this->get_option('delimiter'), $this->get_option('enclosure'));
-		
-		
-		$this->append_to_file('csvexporter.csv', $line_string."\n");
-		
+
+		$this->append_to_file($this->collection_name, $line_string."\n");
 	}
 
 	function get_compound_metadata_cell($meta) {
@@ -214,7 +220,7 @@ class CSV extends Exporter {
 		
 		$line_string = $this->str_putcsv($line, $this->get_option('delimiter'), $this->get_option('enclosure'));
 		
-		$this->append_to_file('csvexporter.csv', $line_string."\n");
+		$this->append_to_file($this->collection_name, $line_string."\n");
 		
 	}
 	
@@ -237,8 +243,8 @@ class CSV extends Exporter {
 	public function get_output() {
 		$files = $this->get_output_files();
 		
-		if ( is_array($files) && isset($files['csvexporter.csv'])) {
-			$file = $files['csvexporter.csv'];
+		if ( is_array($files) && isset($files[$this->collection_name])) {
+			$file = $files[$this->collection_name];
 			$message = __('target collections:', 'tainacan');
 			$message .= " <b>" . implode(", ", $this->get_collections_names() ) . "</b><br/>";
 			$message .= __('Your CSV file is ready! Access it in the link below:', 'tainacan');

--- a/src/classes/exporter/class-tainacan-csv.php
+++ b/src/classes/exporter/class-tainacan-csv.php
@@ -245,8 +245,13 @@ class CSV extends Exporter {
 		
 		if ( is_array($files) && isset($files[$this->collection_name])) {
 			$file = $files[$this->collection_name];
+			$current_user = wp_get_current_user();
+			$author_name = $current_user->user_login;
+
 			$message = __('target collections:', 'tainacan');
 			$message .= " <b>" . implode(", ", $this->get_collections_names() ) . "</b><br/>";
+			$message .= __('Exported by:', 'tainacan');
+			$message .= " <b> ${author_name} </b><br/>";
 			$message .= __('Your CSV file is ready! Access it in the link below:', 'tainacan');
 			$message .= '<br/><br/>';
 			$message .= '<a href="' . $file['url'] . '">Download</a>';

--- a/src/classes/exporter/class-tainacan-exporter.php
+++ b/src/classes/exporter/class-tainacan-exporter.php
@@ -568,7 +568,13 @@ abstract class Exporter {
 
 		$processed_items = $this->get_items($current_collection_item, $collection_definition);
 		foreach ($processed_items as $processed_item) {
+		    $init = microtime(true);
 			$this->process_item( $processed_item['item'], $processed_item['metadata'] );
+			$final = microtime(true);
+			$total = ($final - $init);
+			$time_log = sprintf( __('Processed in %f seconds', 'tainacan'), $total );
+
+            $this->add_log($time_log);
 		}
 
 		$this->process_footer($current_collection_item, $collection_definition);
@@ -617,7 +623,6 @@ abstract class Exporter {
 			$collection_definition['total_items'] = $items->found_posts;
 			$this->update_current_collection($collection_definition);
 		}
-		
 		
 		$data = [];
 		while ($items->have_posts()) {

--- a/src/classes/exporter/class-tainacan-exporter.php
+++ b/src/classes/exporter/class-tainacan-exporter.php
@@ -681,14 +681,15 @@ abstract class Exporter {
 		$upload_dir = trailingslashit( $upload_dir_info['basedir'] );
 		$upload_url = trailingslashit( $upload_dir_info['baseurl'] );
 		$exporter_folder = 'tainacan/exporter';
+		$file_suffix = "{$exporter_folder}/{$prefix}_{$key}";
 
 		if (!is_dir($upload_dir . $exporter_folder)) {
 			if (!mkdir($upload_dir . $exporter_folder)) {
 				return false;
 			}
 		}
-		$file_name = "$upload_dir$exporter_folder/$prefix$key";
-		$file_url = "$upload_url$exporter_folder/$prefix$key";
+		$file_name = "{$upload_dir}{$file_suffix}";
+		$file_url  = "{$upload_url}{$file_suffix}";
 		$this->output_files[$key] = [
 			'filename' => $file_name,
 			'url' => $file_url
@@ -716,7 +717,7 @@ abstract class Exporter {
 	* Method called by Exporters classes to set accepted mapping method
 	* 
 	* @param string $method THe accepted methods. any or list. If list, Exporter must also inform 
-	* default mapper and the list of accepted mappers 
+	* default mapper and the list of accepted mappers
 	* @param string $default_mapping The default mapping method. Required if list is chosen 
 	* @param array $list List of accepted mapping methods 
 	*/

--- a/src/classes/exporter/class-tainacan-exporter.php
+++ b/src/classes/exporter/class-tainacan-exporter.php
@@ -568,13 +568,13 @@ abstract class Exporter {
 
 		$processed_items = $this->get_items($current_collection_item, $collection_definition);
 		foreach ($processed_items as $processed_item) {
-		    $init = microtime(true);
+			$init = microtime(true);
 			$this->process_item( $processed_item['item'], $processed_item['metadata'] );
 			$final = microtime(true);
 			$total = ($final - $init);
 			$time_log = sprintf( __('Processed in %f seconds', 'tainacan'), $total );
 
-            $this->add_log($time_log);
+			$this->add_log($time_log);
 		}
 
 		$this->process_footer($current_collection_item, $collection_definition);

--- a/src/classes/generic-background-process/class-tainacan-bulk-edit-process.php
+++ b/src/classes/generic-background-process/class-tainacan-bulk-edit-process.php
@@ -89,7 +89,7 @@ class Bulk_Edit_Process extends Generic_Process {
         $author_name = $current_user->user_login;
 
         $title_label  = __('Collection', 'tainacan');
-        $author_label = __('Processed by', 'tainacan');
+        $author_label = __('Edited by', 'tainacan');
         $metadata_label = __('Changed metadata', 'tainacan');
 
 	    $message  = __('Bulk edit finished', 'tainacan');

--- a/src/classes/generic-background-process/class-tainacan-bulk-edit-process.php
+++ b/src/classes/generic-background-process/class-tainacan-bulk-edit-process.php
@@ -83,16 +83,16 @@ class Bulk_Edit_Process extends Generic_Process {
 	}
 
 	public function get_output() {
-        $name = $this->get_bulk_collection_name();
-        $metadata = $this->get_changed_metadata();
-        $current_user = wp_get_current_user();
-        $author_name = $current_user->user_login;
+		$name = $this->get_bulk_edit_collection_name();
+		$metadata = $this->get_changed_metadata();
+		$current_user = wp_get_current_user();
+		$author_name = $current_user->user_login;
 
-        $title_label  = __('Collection', 'tainacan');
-        $author_label = __('Edited by', 'tainacan');
-        $metadata_label = __('Changed metadata', 'tainacan');
+		$title_label  = __('Collection', 'tainacan');
+		$author_label = __('Edited by', 'tainacan');
+		$metadata_label = __('Changed metadata', 'tainacan');
 
-	    $message  = __('Bulk edit finished', 'tainacan');
+		$message  = __('Bulk edit finished', 'tainacan');
 		$message .= "<p> <strong> ${title_label}: </strong> ${name} </p>";
 		$message .= "<p> <strong> ${author_label}: </strong> ${author_name} </p>";
 		$message .= "<p> <strong> ${metadata_label}: </strong> ${metadata} </p>";
@@ -100,26 +100,26 @@ class Bulk_Edit_Process extends Generic_Process {
 		return $message;
 	}
 
-	private function get_bulk_collection_name() {
-	    $params =  $this->get_options();
-	    if ($params['collection_id']) {
-	        $collection = $params['collection_id'];
-	        $bulk_collection = Tainacan\Repositories\Collections::get_instance()->fetch($collection);
+	private function get_bulk_edit_collection_name() {
+		$params =  $this->get_options();
+		if ($params['collection_id']) {
+			$collection = $params['collection_id'];
+			$bulk_collection = Tainacan\Repositories\Collections::get_instance()->fetch($collection);
 
-            if ($bulk_collection) {
-                return $bulk_collection->get_name();
-            }
-        }
+			if ($bulk_collection) {
+				return $bulk_collection->get_name();
+			}
+		}
 
-	    return __('Collection', 'tainacan');
-    }
+		return __('Collection', 'tainacan');
+	}
 
-    private function get_changed_metadata() {
-	    $metadatum_id = $this->bulk_edit_data['metadatum_id'];
-        $metadata = get_post($metadatum_id);
+	private function get_changed_metadata() {
+		$metadatum_id = $this->bulk_edit_data['metadatum_id'];
+		$metadata = get_post($metadatum_id);
 
-        return $metadata->post_title;
-    }
+		return $metadata->post_title;
+	}
 
 	public function set_bulk_edit_data($bulk_edit_data = false) {
 		$this->bulk_edit_data = $bulk_edit_data;

--- a/src/classes/generic-background-process/class-tainacan-bulk-edit-process.php
+++ b/src/classes/generic-background-process/class-tainacan-bulk-edit-process.php
@@ -84,10 +84,15 @@ class Bulk_Edit_Process extends Generic_Process {
 
 	public function get_output() {
         $name = $this->get_bulk_collection_name();
-        $title = __('Collection', 'tainacan');
+        $title_label  = __('Collection', 'tainacan');
+        $author_label = __('Processed by', 'tainacan');
+
+        $current_user = wp_get_current_user();
+        $author_name = $current_user->user_login;
 
 	    $message  = __('Bulk edit finished', 'tainacan');
-		$message .= "<p> <strong> ${title}: </strong> ${name} </p>";
+		$message .= "<p> <strong> ${title_label}: </strong> ${name} </p>";
+		$message .= "<p> <strong> ${author_label}: </strong> ${author_name} </p>";
 
 		return $message;
 	}

--- a/src/classes/generic-background-process/class-tainacan-bulk-edit-process.php
+++ b/src/classes/generic-background-process/class-tainacan-bulk-edit-process.php
@@ -106,7 +106,7 @@ class Bulk_Edit_Process extends Generic_Process {
 			$collection = $params['collection_id'];
 			$bulk_collection = Tainacan\Repositories\Collections::get_instance()->fetch($collection);
 
-			if ($bulk_collection) {
+			if ($bulk_collection instanceof \Tainacan\Entities\Collection) {
 				return $bulk_collection->get_name();
 			}
 		}
@@ -115,10 +115,11 @@ class Bulk_Edit_Process extends Generic_Process {
 	}
 
 	private function get_changed_metadata() {
-		$metadatum_id = $this->bulk_edit_data['metadatum_id'];
-		$metadata = get_post($metadatum_id);
-
-		return $metadata->post_title;
+		$metadatum = $this->metadatum_repository->fetch($this->bulk_edit_data['metadatum_id']);
+		if ($metadatum instanceof \Tainacan\Entities\Metadatum) {
+			return $metadatum->get_name();
+		}
+		return __('Metadata', 'tainacan');
 	}
 
 	public function set_bulk_edit_data($bulk_edit_data = false) {

--- a/src/classes/generic-background-process/class-tainacan-bulk-edit-process.php
+++ b/src/classes/generic-background-process/class-tainacan-bulk-edit-process.php
@@ -83,9 +83,28 @@ class Bulk_Edit_Process extends Generic_Process {
 	}
 
 	public function get_output() {
-		$message = __('Bulk edit finished', 'tainacan');
+        $name = $this->get_bulk_collection_name();
+        $title = __('Collection', 'tainacan');
+
+	    $message  = __('Bulk edit finished', 'tainacan');
+		$message .= "<p> <strong> ${title}: </strong> ${name} </p>";
+
 		return $message;
 	}
+
+	private function get_bulk_collection_name() {
+	    $params =  $this->get_options();
+	    if ($params['collection_id']) {
+	        $collection = $params['collection_id'];
+	        $bulk_collection = Tainacan\Repositories\Collections::get_instance()->fetch($collection);
+
+            if ($bulk_collection) {
+                return $bulk_collection->get_name();
+            }
+        }
+
+	    return __('Collection', 'tainacan');
+    }
 
 	public function set_bulk_edit_data($bulk_edit_data = false) {
 		$this->bulk_edit_data = $bulk_edit_data;

--- a/src/classes/generic-background-process/class-tainacan-bulk-edit-process.php
+++ b/src/classes/generic-background-process/class-tainacan-bulk-edit-process.php
@@ -84,15 +84,18 @@ class Bulk_Edit_Process extends Generic_Process {
 
 	public function get_output() {
         $name = $this->get_bulk_collection_name();
-        $title_label  = __('Collection', 'tainacan');
-        $author_label = __('Processed by', 'tainacan');
-
+        $metadata = $this->get_changed_metadata();
         $current_user = wp_get_current_user();
         $author_name = $current_user->user_login;
+
+        $title_label  = __('Collection', 'tainacan');
+        $author_label = __('Processed by', 'tainacan');
+        $metadata_label = __('Changed metadata', 'tainacan');
 
 	    $message  = __('Bulk edit finished', 'tainacan');
 		$message .= "<p> <strong> ${title_label}: </strong> ${name} </p>";
 		$message .= "<p> <strong> ${author_label}: </strong> ${author_name} </p>";
+		$message .= "<p> <strong> ${metadata_label}: </strong> ${metadata} </p>";
 
 		return $message;
 	}
@@ -109,6 +112,13 @@ class Bulk_Edit_Process extends Generic_Process {
         }
 
 	    return __('Collection', 'tainacan');
+    }
+
+    private function get_changed_metadata() {
+	    $metadatum_id = $this->bulk_edit_data['metadatum_id'];
+        $metadata = get_post($metadatum_id);
+
+        return $metadata->post_title;
     }
 
 	public function set_bulk_edit_data($bulk_edit_data = false) {

--- a/src/classes/generic-background-process/class-tainacan-generic-process.php
+++ b/src/classes/generic-background-process/class-tainacan-generic-process.php
@@ -50,18 +50,18 @@ abstract class Generic_Process {
 	];
 
 	/**
-	 * Transients is used to store temporary data to be used accross multiple requests
+	 * Transients are used to store temporary data to be used across multiple requests
 	 *
 	 * Add and remove transient data using add_transient() and delete_transient() methods
 	 *
-	 * Transitens can be strings, numbers or arrays. Avoid storing objects.
+	 * Transients can be strings, numbers or arrays. Avoid storing objects.
 	 * 
 	 * @var array
 	 */
 	protected $transients = [];
 
 	/**
-	 * Wether to abort process execution.
+	 * Whether to abort process execution.
 	 * @var bool
 	 */
 	protected $abort = false;
@@ -74,7 +74,7 @@ abstract class Generic_Process {
 
 	/**
 	 * List of attributes that are saved in DB and that are used to 
-	 * reconstruct the object, this property need be overwrite.
+	 * reconstruct the object, this property needs be overwritten.
 	 * @var array
 	 */
 	protected $array_attributes = [

--- a/src/classes/importer/class-tainacan-bg-importer.php
+++ b/src/classes/importer/class-tainacan-bg-importer.php
@@ -63,8 +63,4 @@ class Background_Importer extends Background_Process {
 		
 	}
 
-	
 }
-
-
- ?>

--- a/src/classes/importer/class-tainacan-csv.php
+++ b/src/classes/importer/class-tainacan-csv.php
@@ -283,7 +283,6 @@ class CSV extends Importer {
 		return false;
 	}
 
-
 	public function options_form() {
 		ob_start();
 		?>
@@ -1018,9 +1017,13 @@ class CSV extends Importer {
 	* @return string
 	*/
 	public function get_output() {
+		$imported_file = basename($this->get_tmp_file());
 
-		$message = __('target collections:', 'tainacan');
+		$message  = __('imported file:', 'tainacan');
+		$message .= " <b> ${imported_file} </b><br/>";
+	  $message .= __('target collections:', 'tainacan');
 		$message .= " <b>" . implode(", ", $this->get_collections_names() ) . "</b><br/>";
+
 		return $message;
 	}
 

--- a/src/classes/importer/class-tainacan-csv.php
+++ b/src/classes/importer/class-tainacan-csv.php
@@ -1018,11 +1018,15 @@ class CSV extends Importer {
 	*/
 	public function get_output() {
 		$imported_file = basename($this->get_tmp_file());
+		$current_user = wp_get_current_user();
+		$author = $current_user->user_login;
 
 		$message  = __('imported file:', 'tainacan');
 		$message .= " <b> ${imported_file} </b><br/>";
 	  $message .= __('target collections:', 'tainacan');
 		$message .= " <b>" . implode(", ", $this->get_collections_names() ) . "</b><br/>";
+		$message .= __('Imported by:', 'tainacan');
+		$message .= " <b> ${author} </b><br/>";
 
 		return $message;
 	}

--- a/src/classes/importer/class-tainacan-csv.php
+++ b/src/classes/importer/class-tainacan-csv.php
@@ -1023,7 +1023,7 @@ class CSV extends Importer {
 
 		$message  = __('imported file:', 'tainacan');
 		$message .= " <b> ${imported_file} </b><br/>";
-	  $message .= __('target collections:', 'tainacan');
+		$message .= __('target collections:', 'tainacan');
 		$message .= " <b>" . implode(", ", $this->get_collections_names() ) . "</b><br/>";
 		$message .= __('Imported by:', 'tainacan');
 		$message .= " <b> ${author} </b><br/>";

--- a/src/classes/importer/class-tainacan-importer.php
+++ b/src/classes/importer/class-tainacan-importer.php
@@ -761,8 +761,6 @@ abstract class Importer {
 		}
 
 		return false;
-
-
 	}
 
     /**
@@ -913,8 +911,6 @@ abstract class Importer {
 		}
 
 		return $return;
-
-
     }
 
     /**
@@ -990,7 +986,6 @@ abstract class Importer {
                     'input_type' => 'tainacan-taxonomy-checkbox'
                 ]);
             }
-
         }
 
         /*Properties of metadatum*/

--- a/src/classes/repositories/class-tainacan-items.php
+++ b/src/classes/repositories/class-tainacan-items.php
@@ -231,7 +231,7 @@ class Items extends Repository {
 		$no_collection_set = false;
 
 		/**
-		 * We can not user $collections->fetch() here because facets
+		 * We can not use $collections->fetch() here because facets
 		 * filter wp_query to just return the query and not the results
 		 * See Repositories\Metadata::fetch_all_metadatum_values()
 		 *


### PR DESCRIPTION
Ref: https://github.com/tainacan/tainacan/issues/436

- Generate a more friendly name for the file to be downloaded:
  - pattern applied: `5f99b6524e372_rock-internacional_csv_export.csv`

- Processing time between one exporting item and another in the log:

![proc-time](https://user-images.githubusercontent.com/1596813/97479818-6bf14d00-1931-11eb-91a0-41b6a97a8ff5.png)

- Show the name of the file used in the importer process
- Display the name of the collection and metadata the bulk edit is being performed on.
- View the user who performed the procedure
![exporter](https://user-images.githubusercontent.com/1596813/97479947-8a574880-1931-11eb-99ba-21c179e7b117.png)
![importer](https://user-images.githubusercontent.com/1596813/97480429-25502280-1932-11eb-98df-04b114058b1c.png)
![bulk-edit](https://user-images.githubusercontent.com/1596813/97480628-706a3580-1932-11eb-9885-dedc6e6d2d6b.png)


