### PR TITLE
Remove HTML link for Relationship values whose target is non-public

### DIFF
--- a/src/views/admin/components/metadata-types/relationship/class-tainacan-relationship.php
+++ b/src/views/admin/components/metadata-types/relationship/class-tainacan-relationship.php
@@ -251,9 +251,13 @@ class Relationship extends Metadata_Type {
 			
 			if (is_string($link)) {
 				
-				$return = "<a data-linkto='item' data-id='$id' href='$link'>";
-				$return.= $label;
-				$return .= "</a>";
+				if ( 'publish' === $item->WP_Post->post_status ) {
+					$return = "<a data-linkto='item' data-id='$id' href='$link'>";
+					$return.= $label;
+					$return .= "</a>";
+				} else {
+					$return.= $label;
+				}
 				
 			}
 			


### PR DESCRIPTION
Simple change to allow relationships to private itens to still be displayed, but without including links. See #514.