### PR TITLE
Adds basic sorting control to faceted search block. #755

### DIFF
--- a/src/views/admin/js/event-bus-search.js
+++ b/src/views/admin/js/event-bus-search.js
@@ -67,7 +67,7 @@ export default {
                         if (this.$route.query.order == undefined || to.params.collectionId != from.params.collectionId) {
                             let orderKey = (this.collectionId != undefined ? 'order_' + this.collectionId : 'order');
                             let orderValue = this.$userPrefs.get(orderKey) ? this.$userPrefs.get(orderKey) : this.defaultOrder;
-
+                            
                             if (orderValue)
                                 this.$route.query.order = orderValue;
                             else {
@@ -80,7 +80,7 @@ export default {
                         if (this.$route.query.orderby == undefined || to.params.collectionId != from.params.collectionId) {
                             let orderByKey = (this.collectionId != undefined ? 'order_by_' + this.collectionId : 'order_by');
                             let orderBy = this.$userPrefs.get(orderByKey) ? this.$userPrefs.get(orderByKey) : this.defaultOrderBy;
-
+                            
                             if (orderBy && orderBy != 'name') {
                                 
                                 // Previously was stored as a metadata object, now it is a orderby object

--- a/src/views/gutenberg-blocks/blocks/faceted-search/block.json
+++ b/src/views/gutenberg-blocks/blocks/faceted-search/block.json
@@ -13,176 +13,204 @@
     },
     "attributes": {
         "termId": {
-            "type": "String",
+            "type": "string",
             "default": null
         },
         "taxonomyId": {
-            "type": "String",
+            "type": "string",
             "default": null
         },
         "collectionId": {
-            "type": "String",
+            "type": "string",
             "default": null
         },
         "defaultViewMode": {
-            "type": "String",
+            "type": "string",
             "default": "masonry"
         },
         "enabledViewModes": {
-            "type": "Array",
+            "type": "array",
             "default": null
         },
         "collectionDefaultViewMode": {
-            "type": "String",
+            "type": "string",
             "default": "masonry"
         },
         "collectionEnabledViewModes": {
-            "type": "Array",
+            "type": "array",
             "default": []
         },
         "hideFilters": {
-            "type": "Boolean",
+            "type": "boolean",
             "default": false
         },
         "hideHideFiltersButton": {
-            "type": "Boolean",
+            "type": "boolean",
             "default": false
         },
         "hideSearch": {
-            "type": "Boolean",
+            "type": "boolean",
             "default": false
         },
         "hideAdvancedSearch": {
-            "type": "Boolean",
+            "type": "boolean",
             "default": false
         },
         "hideDisplayedMetadataButton": {
-            "type": "Boolean",
+            "type": "boolean",
             "default": false
         },
         "hideSortingArea": {
-            "type": "Boolean",
+            "type": "boolean",
             "default": false
         },
         "hideSortByButton": {
-            "type": "Boolean",
+            "type": "boolean",
             "default": false
         },
         "hideItemsThumbnail": {
-            "type": "Boolean",
+            "type": "boolean",
             "default": false
         },
         "hideExposersButton": {
-            "type": "Boolean",
+            "type": "boolean",
             "default": false
         },
         "hideItemsPerPageButton": {
-            "type": "Boolean",
+            "type": "boolean",
             "default": false
         },
         "defaultItemsPerPage": {
-            "type": "Number",
+            "type": "number",
             "default": 12
         },
         "hideGoToPageButton": {
-            "type": "Boolean",
+            "type": "boolean",
             "default": false
         },
         "hidePaginationArea": {
-            "type": "Boolean",
+            "type": "boolean",
             "default": false
         },
         "showFiltersButtonInsideSearchControl": {
-            "type": "Boolean",
+            "type": "boolean",
             "default": false
         },
         "startWithFiltersHidden": {
-            "type": "Boolean",
+            "type": "boolean",
             "default": false
         },
         "filtersAsModal": {
-            "type": "Boolean",
+            "type": "boolean",
             "default": false
         },
         "showInlineViewModeOptions": {
-            "type": "Boolean",
+            "type": "boolean",
             "default": false
         },
         "showFullscreenWithViewModes": {
-            "type": "Boolean",
+            "type": "boolean",
             "default": false
         },
         "listType": {
-            "type": "String",
+            "type": "string",
             "default": ""
         },
         "isCollectionModalOpen": {
-            "type": "Boolean",
+            "type": "boolean",
             "default": false
         },
         "isTermModalOpen": {
-            "type": "Boolean",
+            "type": "boolean",
             "default": false
         },
         "backgroundColor": {
-            "type": "String",
+            "type": "string",
             "default": "#ffffff"
         },
         "baseFontSize": {
-            "type": "Number",
+            "type": "number",
             "default": 16
         },
         "filtersAreaWidth": {
-            "type": "Number",
+            "type": "number",
             "default": 20
         },
         "inputColor": {
-            "type": "String",
+            "type": "string",
             "default": "#1d1d1d"
         },
         "inputBackgroundColor": {
-            "type": "String",
+            "type": "string",
             "default": "#ffffff"
         },
         "inputBorderColor": {
-            "type": "String",
+            "type": "string",
             "default": "#dbdbdb"
         },
         "labelColor": {
-            "type": "String",
+            "type": "string",
             "default": "#454647"
         },
         "infoColor": {
-            "type": "String",
+            "type": "string",
             "default": "#555758"
         },
         "headingColor": {
-            "type": "String",
+            "type": "string",
             "default": "#000000"
         },
         "skeletonColor": {
-            "type": "String",
+            "type": "string",
             "default": "#eeeeee"
         },
         "itemBackgroundColor": {
-            "type": "String",
+            "type": "string",
             "default": "#ffffff"
         },
         "itemHoverBackgroundColor": {
-            "type": "String",
+            "type": "string",
             "default": "#f2f2f2"
         },
         "itemHeadingHoverBackgroundColor": {
-            "type": "String",
+            "type": "string",
             "default": "#dbdbdb"
         },
         "primaryColor": {
-            "type": "String",
+            "type": "string",
             "default": "#d9eced"
         },
         "secondaryColor": {
-            "type": "String",
+            "type": "string",
             "default": "#298596"
+        },
+        "order": {
+            "type": "string",
+            "default": "ASC"
+        },
+        "orderBy": {
+            "type": "string",
+            "default": "date"
+        },
+        "orderByMeta": {
+            "type": "string",
+            "default": ""
+        },
+        "orderByType": {
+            "type": "string",
+            "default": ""
+        },
+        "collectionOrderBy": {
+            "type": "string",
+            "default": "date"
+        },
+        "collectionOrderByMeta": {
+            "type": "string",
+            "default": ""
+        },
+        "collectionOrderByType": {
+            "type": "string",
+            "default": ""
         }
     },
     "supports": {

--- a/src/views/gutenberg-blocks/blocks/faceted-search/collection-modal.js
+++ b/src/views/gutenberg-blocks/blocks/faceted-search/collection-modal.js
@@ -13,17 +13,25 @@ export default class CollectionModal extends React.Component {
 
         // Initialize state
         this.state = {
+            collectionDefaultOrderBy: 'date',
+            collectionDefaultOrder: 'ASC',
+            collectionDefaultOrderByMeta: '',
+            collectionDefaultOrderByType: '',
             collectionViewModes: [],
             collectionsPerPage: 24,
             collectionId: undefined,  
             isLoadingCollections: false, 
             modalCollections: [],
             totalModalCollections: 0, 
-            collectionPage: 1,
-            collectionOrderBy: 'date-desc',
+            collectionsPage: 1,
+            collectionsOrderBy: 'date-desc',
             temporaryCollectionId: '',
             temporaryCollectionDefaultViewMode: '',
             temporaryCollectionEnabledViewModes: [],
+            temporaryCollectionDefaultOrderBy: 'date',
+            temporaryCollectionDefaultOrderByMeta: '',
+            temporaryCollectionDefaultOrderByType: '',
+            temporaryCollectionDefaultOrder: 'ASC',
             searchCollectionName: '',
             collections: [],
             collectionsRequestSource: undefined
@@ -43,7 +51,11 @@ export default class CollectionModal extends React.Component {
             temporaryCollectionId: this.props.existingCollectionId,
             temporaryCollectionDefaultViewMode: this.props.existingCollectionDefaultViewMode,
             temporaryCollectionEnabledViewModes: this.props.existingCollectionEnabledViewModes,
-            collectionPage: 1
+            temporaryCollectionDefaultOrder: this.props.existingCollectionDefaultOrder,
+            temporaryCollectionDefaultOrderBy: this.props.existingCollectionDefaultOrderBy,
+            temporaryCollectionDefaultOrderByMeta: this.props.existingCollectionDefaultOrderByMeta,
+            temporaryCollectionDefaultOrderByType: this.props.existingCollectionDefaultOrderByType,
+            collectionsPage: 1
         });
 
         this.fetchModalCollections();
@@ -62,12 +74,12 @@ export default class CollectionModal extends React.Component {
     fetchModalCollections() {
 
         let someModalCollections = this.state.modalCollections;
-        if (this.state.collectionPage <= 1)
+        if (this.state.collectionsPage <= 1)
             someModalCollections = [];
 
         let query = {
             perpage: this.state.collectionsPerPage,
-            paged: this.state.collectionPage
+            paged: this.state.collectionsPage
         }
 
         if (this.props.filterOptionsBy && Object.keys(this.props.filterOptionsBy).length !== 0) {
@@ -84,18 +96,18 @@ export default class CollectionModal extends React.Component {
             
         let endpoint = '/collections/?' + qs.stringify(query); 
 
-        if (this.state.collectionOrderBy == 'date')
+        if (this.state.collectionsOrderBy == 'date')
             endpoint += '&orderby=date&order=asc';
-        else if (this.state.collectionOrderBy == 'date-desc')
+        else if (this.state.collectionsOrderBy == 'date-desc')
             endpoint += '&orderby=date&order=desc';
-        else if (this.state.collectionOrderBy == 'title')
+        else if (this.state.collectionsOrderBy == 'title')
             endpoint += '&orderby=title&order=asc';
-        else if (this.state.collectionOrderBy == 'title-desc')
+        else if (this.state.collectionsOrderBy == 'title-desc')
             endpoint += '&orderby=title&order=desc';
 
         this.setState({ 
             isLoadingCollections: true,
-            collectionPage: this.state.collectionPage + 1, 
+            collectionsPage: this.state.collectionsPage + 1, 
             modalCollections: someModalCollections
         });
 
@@ -108,7 +120,9 @@ export default class CollectionModal extends React.Component {
                         name: collection.name, 
                         id: collection.id,
                         default_view_mode: collection.default_view_mode,
-                        enabled_view_modes: collection.enabled_view_modes
+                        enabled_view_modes: collection.enabled_view_modes,
+                        default_orderby: collection.default_orderby,
+                        default_order: collection.default_order
                     });
                 }
 
@@ -125,10 +139,10 @@ export default class CollectionModal extends React.Component {
             });
     }
 
-    selectCollection({ collectionId, collectionDefaultViewMode, collectionEnabledViewModes }) {
+    selectCollection({ collectionId, collectionDefaultViewMode, collectionEnabledViewModes, collectionDefaultOrder, collectionDefaultOrderBy, collectionDefaultOrderByMeta, collectionDefaultOrderByType }) {
         collectionId = collectionId;
         this.setState({ collectionId: collectionId });
-        this.props.onSelectCollection({ collectionId, collectionDefaultViewMode, collectionEnabledViewModes });
+        this.props.onSelectCollection({ collectionId, collectionDefaultViewMode, collectionEnabledViewModes, collectionDefaultOrder, collectionDefaultOrderBy, collectionDefaultOrderByMeta, collectionDefaultOrderByType });
     }
 
     fetchCollections(name) {
@@ -146,7 +160,7 @@ export default class CollectionModal extends React.Component {
 
         let query = {
             perpage: this.state.collectionsPerPage,
-            paged: this.state.collectionPage
+            paged: this.state.collectionsPage
         }
 
         if (this.props.filterOptionsBy && Object.keys(this.props.filterOptionsBy).length !== 0) {
@@ -166,13 +180,13 @@ export default class CollectionModal extends React.Component {
         if (name != undefined && name != '')
             endpoint += '&search=' + name;
         
-        if (this.state.collectionOrderBy == 'date')
+        if (this.state.collectionsOrderBy == 'date')
             endpoint += '&orderby=date&order=asc';
-        else if (this.state.collectionOrderBy == 'date-desc')
+        else if (this.state.collectionsOrderBy == 'date-desc')
             endpoint += '&orderby=date&order=desc';
-        else if (this.state.collectionOrderBy == 'title')
+        else if (this.state.collectionsOrderBy == 'title')
             endpoint += '&orderby=title&order=asc';
-        else if (this.state.collectionOrderBy == 'title-desc')
+        else if (this.state.collectionsOrderBy == 'title-desc')
             endpoint += '&orderby=title&order=desc';
 
         tainacan.get(endpoint, { cancelToken: aCollectionRequestSource.token })
@@ -181,7 +195,9 @@ export default class CollectionModal extends React.Component {
                     name: collection.name, 
                     id: collection.id + '',
                     default_view_mode: collection.default_view_mode,
-                    enabled_view_modes: collection.enabled_view_modes
+                    enabled_view_modes: collection.enabled_view_modes,
+                    default_orderby: collection.default_orderby,
+                    default_order: collection.default_order
                 }));
 
                 this.setState({ 
@@ -200,7 +216,7 @@ export default class CollectionModal extends React.Component {
 
         this.setState({
             collectionId: null,
-            collectionPage: 1,
+            collectionsPage: 1,
             modalCollections: []
         });
         this.fetchModalCollections(); 
@@ -227,19 +243,19 @@ export default class CollectionModal extends React.Component {
                                 }}/>
                         <SelectControl
                                 label={__('Order by', 'tainacan')}
-                                value={ this.state.collectionOrderBy }
+                                value={ this.state.collectionsOrderBy }
                                 options={ [
                                     { label: __('Latest', 'tainacan'), value: 'date-desc' },
                                     { label: __('Oldest', 'tainacan'), value: 'date' },
                                     { label: __('Name (A-Z)', 'tainacan'), value: 'title' },
                                     { label: __('Name (Z-A)', 'tainacan'), value: 'title-desc' }
                                 ] }
-                                onChange={ ( aCollectionOrderBy ) => { 
-                                    this.state.collectionOrderBy = aCollectionOrderBy;
-                                    this.state.collectionPage = 1;
+                                onChange={ ( acollectionsOrderBy ) => { 
+                                    this.state.collectionsOrderBy = acollectionsOrderBy;
+                                    this.state.collectionsPage = 1;
                                     this.setState({ 
-                                        collectionOrderBy: this.state.collectionOrderBy,
-                                        collectionPage: this.state.collectionPage 
+                                        collectionsOrderBy: this.state.collectionsOrderBy,
+                                        collectionsPage: this.state.collectionsPage 
                                     });
                                     if (this.state.searchCollectionName && this.state.searchCollectionName != '') {
                                         this.fetchCollections(this.state.searchCollectionName);
@@ -267,9 +283,17 @@ export default class CollectionModal extends React.Component {
                                             this.state.temporaryCollectionId = aCollectionId;
                                             this.state.temporaryCollectionDefaultViewMode = selectedCollection.default_view_mode;
                                             this.state.temporaryCollectionEnabledViewModes = selectedCollection.enabled_view_modes;
+                                            this.state.temporaryCollectionDefaultOrder = selectedCollection.default_order;
+                                            this.state.temporaryCollectionDefaultOrderBy = selectedCollection.default_orderby.orderby ? selectedCollection.default_orderby.orderby : selectedCollection.default_orderby;
+                                            this.state.temporaryCollectionDefaultOrderByMeta = selectedCollection.default_orderby.metakey ? selectedCollection.default_orderby.metakey : '';
+                                            this.state.temporaryCollectionDefaultOrderByType = selectedCollection.default_orderby.metatype ? selectedCollection.default_orderby.metatype : '';
                                             this.setState({ temporaryCollectionId: aCollectionId });
                                             this.setState({ temporaryCollectionDefaultViewMode: selectedCollection.default_view_mode });
                                             this.setState({ temporaryCollectionEnabledViewModes: selectedCollection.enabled_view_modes });
+                                            this.setState({ temporaryCollectionDefaultOrder: selectedCollection.default_order });
+                                            this.setState({ temporaryCollectionDefaultOrderBy: selectedCollection.default_orderby.orderby ? selectedCollection.default_orderby.orderby : selectedCollection.default_orderby });
+                                            this.setState({ temporaryCollectionDefaultOrderByMeta: selectedCollection.default_orderby.metakey ? selectedCollection.default_orderby.metakey : '' });
+                                            this.setState({ temporaryCollectionDefaultOrderByType: selectedCollection.default_orderby.metatype ? selectedCollection.default_orderby.metatype : '' });
                                         } } />
                                     }                                      
                                 </div>
@@ -299,9 +323,19 @@ export default class CollectionModal extends React.Component {
                                         this.state.temporaryCollectionId = aCollectionId;
                                         this.state.temporaryCollectionDefaultViewMode = selectedCollection.default_view_mode;
                                         this.state.temporaryCollectionEnabledViewModes = selectedCollection.enabled_view_modes;
+                                        this.state.temporaryCollectionDefaultOrder = selectedCollection.default_order;
+                                        this.state.temporaryCollectionDefaultOrderBy = selectedCollection.default_orderby;
+                                        this.state.temporaryCollectionDefaultOrderBy = selectedCollection.default_orderby.orderby ? selectedCollection.default_orderby.orderby : selectedCollection.default_orderby;
+                                        this.state.temporaryCollectionDefaultOrderByMeta = selectedCollection.default_orderby.metakey ? selectedCollection.default_orderby.metakey : '';
+                                        this.state.temporaryCollectionDefaultOrderByType = selectedCollection.default_orderby.metatype ? selectedCollection.default_orderby.metatype : '';
                                         this.setState({ temporaryCollectionId: aCollectionId });
                                         this.setState({ temporaryCollectionDefaultViewMode: selectedCollection.default_view_mode });
                                         this.setState({ temporaryCollectionEnabledViewModes: selectedCollection.enabled_view_modes });
+                                        this.setState({ temporaryCollectionDefaultOrder: selectedCollection.default_order });
+                                        this.setState({ temporaryCollectionDefaultOrderBy: selectedCollection.default_orderby });
+                                        this.setState({ temporaryCollectionDefaultOrderBy: selectedCollection.default_orderby.orderby ? selectedCollection.default_orderby.orderby : selectedCollection.default_orderby });
+                                        this.setState({ temporaryCollectionDefaultOrderByMeta: selectedCollection.default_orderby.metakey ? selectedCollection.default_orderby.metakey : '' });
+                                        this.setState({ temporaryCollectionDefaultOrderByType: selectedCollection.default_orderby.metatype ? selectedCollection.default_orderby.metatype : '' });
                                     } } />
                                 }                                     
                             </div>
@@ -336,7 +370,11 @@ export default class CollectionModal extends React.Component {
                         onClick={ () => this.selectCollection({ 
                             collectionId: this.state.temporaryCollectionId,
                             collectionDefaultViewMode: this.state.temporaryCollectionDefaultViewMode,
-                            collectionEnabledViewModes: this.state.temporaryCollectionEnabledViewModes
+                            collectionEnabledViewModes: this.state.temporaryCollectionEnabledViewModes,
+                            collectionDefaultOrder: this.state.temporaryCollectionDefaultOrder,
+                            collectionDefaultOrderBy: this.state.temporaryCollectionDefaultOrderBy,
+                            collectionDefaultOrderByMeta: this.state.temporaryCollectionDefaultOrderByMeta,
+                            collectionDefaultOrderByType: this.state.temporaryCollectionDefaultOrderByType
                         }) }>
                         {__('Use selected Collection', 'tainacan')}
                     </Button>

--- a/src/views/gutenberg-blocks/blocks/faceted-search/deprecated.js
+++ b/src/views/gutenberg-blocks/blocks/faceted-search/deprecated.js
@@ -1,4 +1,289 @@
 export default [
+    /* Deprecated in version 0.19.4 due to add of orderby, orderbymeta and orderbykey */
+    {
+        attributes: {
+            "termId": {
+                "type": "String",
+                "default": null
+            },
+            "taxonomyId": {
+                "type": "String",
+                "default": null
+            },
+            "collectionId": {
+                "type": "String",
+                "default": null
+            },
+            "defaultViewMode": {
+                "type": "String",
+                "default": "masonry"
+            },
+            "enabledViewModes": {
+                "type": "Array",
+                "default": null
+            },
+            "collectionDefaultViewMode": {
+                "type": "String",
+                "default": "masonry"
+            },
+            "collectionEnabledViewModes": {
+                "type": "Array",
+                "default": []
+            },
+            "hideFilters": {
+                "type": "Boolean",
+                "default": false
+            },
+            "hideHideFiltersButton": {
+                "type": "Boolean",
+                "default": false
+            },
+            "hideSearch": {
+                "type": "Boolean",
+                "default": false
+            },
+            "hideAdvancedSearch": {
+                "type": "Boolean",
+                "default": false
+            },
+            "hideDisplayedMetadataButton": {
+                "type": "Boolean",
+                "default": false
+            },
+            "hideSortingArea": {
+                "type": "Boolean",
+                "default": false
+            },
+            "hideSortByButton": {
+                "type": "Boolean",
+                "default": false
+            },
+            "hideItemsThumbnail": {
+                "type": "Boolean",
+                "default": false
+            },
+            "hideExposersButton": {
+                "type": "Boolean",
+                "default": false
+            },
+            "hideItemsPerPageButton": {
+                "type": "Boolean",
+                "default": false
+            },
+            "defaultItemsPerPage": {
+                "type": "Number",
+                "default": 12
+            },
+            "hideGoToPageButton": {
+                "type": "Boolean",
+                "default": false
+            },
+            "hidePaginationArea": {
+                "type": "Boolean",
+                "default": false
+            },
+            "showFiltersButtonInsideSearchControl": {
+                "type": "Boolean",
+                "default": false
+            },
+            "startWithFiltersHidden": {
+                "type": "Boolean",
+                "default": false
+            },
+            "filtersAsModal": {
+                "type": "Boolean",
+                "default": false
+            },
+            "showInlineViewModeOptions": {
+                "type": "Boolean",
+                "default": false
+            },
+            "showFullscreenWithViewModes": {
+                "type": "Boolean",
+                "default": false
+            },
+            "listType": {
+                "type": "String",
+                "default": ""
+            },
+            "isCollectionModalOpen": {
+                "type": "Boolean",
+                "default": false
+            },
+            "isTermModalOpen": {
+                "type": "Boolean",
+                "default": false
+            },
+            "backgroundColor": {
+                "type": "String",
+                "default": "#ffffff"
+            },
+            "baseFontSize": {
+                "type": "Number",
+                "default": 16
+            },
+            "filtersAreaWidth": {
+                "type": "Number",
+                "default": 20
+            },
+            "inputColor": {
+                "type": "String",
+                "default": "#1d1d1d"
+            },
+            "inputBackgroundColor": {
+                "type": "String",
+                "default": "#ffffff"
+            },
+            "inputBorderColor": {
+                "type": "String",
+                "default": "#dbdbdb"
+            },
+            "labelColor": {
+                "type": "String",
+                "default": "#454647"
+            },
+            "infoColor": {
+                "type": "String",
+                "default": "#555758"
+            },
+            "headingColor": {
+                "type": "String",
+                "default": "#000000"
+            },
+            "skeletonColor": {
+                "type": "String",
+                "default": "#eeeeee"
+            },
+            "itemBackgroundColor": {
+                "type": "String",
+                "default": "#ffffff"
+            },
+            "itemHoverBackgroundColor": {
+                "type": "String",
+                "default": "#f2f2f2"
+            },
+            "itemHeadingHoverBackgroundColor": {
+                "type": "String",
+                "default": "#dbdbdb"
+            },
+            "primaryColor": {
+                "type": "String",
+                "default": "#d9eced"
+            },
+            "secondaryColor": {
+                "type": "String",
+                "default": "#298596"
+            }
+        },
+        supports: {
+            align: ['full', 'wide'],
+            html: true,
+            multiple: false
+        },
+        save({ attributes, className }) {
+            const {
+                termId,
+                taxonomyId,
+                collectionId,
+                defaultViewMode,
+                enabledViewModes,
+                collectionDefaultViewMode,
+                collectionEnabledViewModes,
+                hideDisplayedMetadataButton,
+                hideSortingArea,
+                hideFilters,
+                hideHideFiltersButton,
+                hideSearch,
+                hideAdvancedSearch,
+                hideSortByButton,
+                hideItemsThumbnail,
+                hidePaginationArea,
+                hideExposersButton,
+                hideItemsPerPageButton,
+                defaultItemsPerPage,
+                hideGoToPageButton,
+                showFiltersButtonInsideSearchControl,
+                startWithFiltersHidden,
+                filtersAsModal,
+                showInlineViewModeOptions,
+                showFullscreenWithViewModes,
+                listType,
+                backgroundColor,
+                baseFontSize,
+                filtersAreaWidth,
+                inputColor,
+                inputBackgroundColor,
+                inputBorderColor,
+                labelColor,
+                infoColor,
+                headingColor,
+                skeletonColor,
+                itemBackgroundColor,
+                itemHoverBackgroundColor,
+                itemHeadingHoverBackgroundColor,
+                primaryColor,
+                secondaryColor
+            } = attributes;
+            
+            let updatedListType = '' + listType;
+        
+            if (updatedListType === '' && collectionId)
+                updatedListType = 'collection';
+            else if (updatedListType === '' && termId && taxonomyId)
+                updatedListType = 'term';
+                
+            return <div 
+                    style={{
+                        'font-size': baseFontSize + 'px',
+                        '--tainacan-base-font-size': baseFontSize + 'px',
+                        '--tainacan-background-color': backgroundColor,
+                        '--tainacan-filter-menu-width-theme': filtersAreaWidth + '%',
+                        '--tainacan-input-color': inputColor,
+                        '--tainacan-input-background-color': inputBackgroundColor,
+                        '--tainacan-input-border-color': inputBorderColor,
+                        '--tainacan-label-color': labelColor,
+                        '--tainacan-info-color': infoColor,
+                        '--tainacan-heading-color': headingColor,
+                        '--tainacan-skeleton-color': skeletonColor,
+                        '--tainacan-item-background-color': itemBackgroundColor,
+                        '--tainacan-item-hover-background-color': itemHoverBackgroundColor,
+                        '--tainacan-item-heading-hover-background-color': itemHeadingHoverBackgroundColor,
+                        '--tainacan-primary': primaryColor,
+                        '--tainacan-secondary': secondaryColor
+                    }}
+                    className={ className }>
+                <main 
+                        id="tainacan-items-page"
+                        data-module="faceted-search"
+                        term-id={ updatedListType == 'term' ? termId : null }
+                        taxonomy={ updatedListType == 'term' ? 'tnc_tax_' + taxonomyId : null  }
+                        collection-id={ updatedListType == 'collection' ? collectionId : null }  
+                        default-view-mode={ defaultViewMode != 'none' ? defaultViewMode : (updatedListType == 'collection' ? collectionDefaultViewMode : (hideItemsThumbnail ? 'table' : 'masonry') ) }
+                        is-forced-view-mode={ defaultViewMode == 'none' ? 'true' : 'false' }
+                        enabled-view-modes={ enabledViewModes.toString() }  
+                        hide-filters = { hideFilters.toString() }
+                        hide-hide-filters-button= { hideHideFiltersButton.toString() }
+                        hide-search = { hideSearch.toString() }
+                        hide-advanced-search = { hideAdvancedSearch.toString() }
+                        hide-displayed-metadata-button = { hideDisplayedMetadataButton.toString() }
+                        hide-pagination-area = { hidePaginationArea.toString() }
+                        hide-sorting-area = { hideSortingArea.toString() }
+                        hide-items-thumbnail = { hideItemsThumbnail ? hideItemsThumbnail.toString() : 'false' }
+                        hide-sort-by-button = { hideSortByButton.toString() }
+                        hide-pagination-area = { hidePaginationArea.toString() }
+                        hide-exposers-button = { hideExposersButton.toString() }
+                        hide-items-per-page-button = { hideItemsPerPageButton.toString() }
+                        default-items-per-page = { defaultItemsPerPage }
+                        hide-go-to-page-button = { hideGoToPageButton.toString() }
+                        show-filters-button-inside-search-control = { showFiltersButtonInsideSearchControl.toString() }
+                        start-with-filters-hidden = { startWithFiltersHidden.toString() }
+                        filters-as-modal = { filtersAsModal.toString() }
+                        show-inline-view-mode-options = { showInlineViewModeOptions.toString() }
+                        show-fullscreen-with-view-modes = { showFullscreenWithViewModes.toString() } >
+                </main>
+            </div>
+        }
+    },
     /* Deprecated in version 0.18.4 due to WP 5.8 support */
     {
         attributes: {

--- a/src/views/gutenberg-blocks/blocks/faceted-search/edit.js
+++ b/src/views/gutenberg-blocks/blocks/faceted-search/edit.js
@@ -2,7 +2,6 @@ const { __ } = wp.i18n;
 
 const { 
     Button,
-    ColorPalette,
     BaseControl,
     CheckboxControl,
     RangeControl,
@@ -417,6 +416,50 @@ export default function({ attributes, setAttributes, className, isSelected, clie
                                 } 
                             }
                         />
+
+                        <BaseControl
+                                id="defaulOrder"
+                                label={ __('Default order', 'tainacan')}
+                                help={ __('The default sorting direction', 'tainacan') }>
+                            <SelectControl
+                                    label={ __('Default order', 'tainacan') }
+                                    hideLabelFromVision
+                                    value={ order }
+                                    options={
+                                        [
+                                            { value: 'ASC', label: __('Ascending', 'tainacan') },
+                                            { value: 'DESC', label: __('Descending', 'tainacan') }
+                                        ]
+                                    }
+                                    onChange={ (anOrder) => {
+                                        order = anOrder;
+                                        setAttributes({ order: anOrder });
+                                    } }
+                                />
+                        </BaseControl>
+
+                        { listType != 'collection' ?
+                            <BaseControl
+                                    id="defaulOrderBy"
+                                    label={ __('Default order by', 'tainacan')}
+                                    help={ __('The default metadata by which the sorting will be applied', 'tainacan') }>
+                                <SelectControl
+                                        label={ __('Default order by', 'tainacan') }
+                                        hideLabelFromVision
+                                        value={ orderBy }
+                                        options={
+                                            [
+                                                { value: 'date', label: __('Creation date', 'tainacan') },
+                                                { value: 'title', label: __('Title', 'tainacan') }
+                                            ]
+                                        }
+                                        onChange={ (anOrderBy) => {
+                                            orderBy = anOrderBy;
+                                            setAttributes({ orderBy: anOrderBy });
+                                        } }
+                                    />
+                            </BaseControl>
+                        : null }
 
                         <BaseControl
                                 id="defaultViewModeSelect"

--- a/src/views/gutenberg-blocks/blocks/faceted-search/edit.js
+++ b/src/views/gutenberg-blocks/blocks/faceted-search/edit.js
@@ -70,7 +70,14 @@ export default function({ attributes, setAttributes, className, isSelected, clie
         itemHoverBackgroundColor,
         itemHeadingHoverBackgroundColor,
         primaryColor,
-        secondaryColor
+        secondaryColor,
+        order,
+        orderBy,
+        orderByMeta,
+        orderByType,
+        collectionOrderBy,
+        collectionOrderByMeta,
+        collectionOrderByType
     } = attributes;
 
     let registeredViewModesEntries = [];
@@ -976,18 +983,31 @@ export default function({ attributes, setAttributes, className, isSelected, clie
             { isCollectionModalOpen ? 
                 <CollectionModal
                     existingCollectionId={ collectionId }  
+                    existingCollectionDefaultOrder={ order } 
+                    existingCollectionDefaultOrderBy={ collectionOrderBy }
+                    existingCollectionDefaultOrderByMeta={ collectionOrderByMeta }
+                    existingCollectionDefaultOrderByType={ collectionOrderByType } 
                     existingCollectionDefaultViewMode={ collectionDefaultViewMode } 
                     existingCollectionEnabledViewModes={ collectionEnabledViewModes }
-                    onSelectCollection={ ({ collectionId, collectionDefaultViewMode, collectionEnabledViewModes }) => {
+                    onSelectCollection={ ({ collectionId, collectionDefaultViewMode, collectionEnabledViewModes, collectionDefaultOrder, collectionDefaultOrderBy, collectionDefaultOrderByMeta, collectionDefaultOrderByType }) => {
                         collectionId = collectionId;
                         collectionDefaultViewMode = collectionDefaultViewMode ? collectionDefaultViewMode : defaultViewMode;
                         collectionEnabledViewModes = collectionEnabledViewModes && collectionEnabledViewModes.length ? collectionEnabledViewModes : enabledViewModes;
+                        order = collectionDefaultOrder ? collectionDefaultOrder : 'ASC';
+                        collectionOrderBy = collectionDefaultOrderBy ? collectionDefaultOrderBy : 'date';
+                        collectionOrderByMeta = collectionDefaultOrderByMeta ? collectionDefaultOrderByMeta : '';
+                        collectionOrderByType = collectionDefaultOrderByType ? collectionDefaultOrderByType : '';
+                        console.log(collectionDefaultOrderByMeta)
                         setAttributes({
                             collectionId: collectionId, 
                             collectionDefaultViewMode: collectionDefaultViewMode,
                             defaultViewMode: collectionDefaultViewMode,
                             collectionEnabledViewModes: collectionEnabledViewModes,
                             enabledViewModes: collectionEnabledViewModes,
+                            order: order,
+                            collectionOrderBy, collectionOrderBy,
+                            collectionOrderByMeta: collectionOrderByMeta,
+                            collectionOrderByType: collectionOrderByType,
                             isCollectionModalOpen: false
                         });
                     }}

--- a/src/views/gutenberg-blocks/blocks/faceted-search/save.js
+++ b/src/views/gutenberg-blocks/blocks/faceted-search/save.js
@@ -40,7 +40,14 @@ export default function({ attributes, className }) {
         itemHoverBackgroundColor,
         itemHeadingHoverBackgroundColor,
         primaryColor,
-        secondaryColor
+        secondaryColor,
+        order,
+        orderBy,
+        orderByMeta,
+        orderByType,
+        collectionOrderBy,
+        collectionOrderByMeta,
+        collectionOrderByType
     } = attributes;
     
     let updatedListType = '' + listType;
@@ -88,7 +95,6 @@ export default function({ attributes, className }) {
                 hide-sorting-area = { hideSortingArea.toString() }
                 hide-items-thumbnail = { hideItemsThumbnail ? hideItemsThumbnail.toString() : 'false' }
                 hide-sort-by-button = { hideSortByButton.toString() }
-                hide-pagination-area = { hidePaginationArea.toString() }
                 hide-exposers-button = { hideExposersButton.toString() }
                 hide-items-per-page-button = { hideItemsPerPageButton.toString() }
                 default-items-per-page = { defaultItemsPerPage }
@@ -97,7 +103,11 @@ export default function({ attributes, className }) {
                 start-with-filters-hidden = { startWithFiltersHidden.toString() }
                 filters-as-modal = { filtersAsModal.toString() }
                 show-inline-view-mode-options = { showInlineViewModeOptions.toString() }
-                show-fullscreen-with-view-modes = { showFullscreenWithViewModes.toString() } >
+                show-fullscreen-with-view-modes = { showFullscreenWithViewModes.toString() } 
+                default-order = { order ? order : 'ASC' }
+                default-orderby = { updatedListType == 'collection' ? (collectionOrderBy ? collectionOrderBy : 'date') : (orderBy ? orderBy : 'date') }
+                default-orderby-meta = { updatedListType == 'collection' ? (collectionOrderByMeta ? collectionOrderByMeta : '') : (orderByMeta ? orderByMeta : '') }
+                default-orderby-type = { updatedListType == 'collection' ? (collectionOrderByType ? collectionOrderByType : '') : (orderByType ? orderByType : '') } >
         </main>
     </div>
 };

--- a/src/views/gutenberg-blocks/blocks/faceted-search/theme-search/theme-items-page.vue
+++ b/src/views/gutenberg-blocks/blocks/faceted-search/theme-search/theme-items-page.vue
@@ -859,7 +859,6 @@
                 this.$eventBusSearch.setTerm(this.termId, this.taxonomy);
             if (this.defaultOrder != undefined) {
                 this.$eventBusSearch.setDefaultOrder(this.defaultOrder);
-
                 if (!this.$route.query.order)
                     this.$eventBusSearch.setOrder(this.defaultOrder);
             }

--- a/src/views/gutenberg-blocks/blocks/faceted-search/theme-search/theme-items-page.vue
+++ b/src/views/gutenberg-blocks/blocks/faceted-search/theme-search/theme-items-page.vue
@@ -728,6 +728,8 @@
             // Other Tweaks
             defaultOrder: 'ASC',
             defaultOrderBy: 'date',
+            defaultOrderByMeta: '',
+            defaultOrderByType: '',
             defaultItemsPerPage: Number,
             showFiltersButtonInsideSearchControl: false,
             startWithFiltersHidden: false,
@@ -767,7 +769,7 @@
         },
         computed: {
             isSortingByCustomMetadata() {
-                return (this.orderBy != undefined && this.orderBy != '' && this.orderBy != 'title' && this.orderBy != 'date'); 
+                return (this.orderBy != undefined && this.orderBy != '' && this.orderBy != 'title' && this.orderBy != 'date' && this.orderBy != 'modified'); 
             },
             items() {
                 return this.getItems();
@@ -855,10 +857,34 @@
                 this.$eventBusSearch.setCollectionId(this.collectionId);
             if (this.termId != undefined && this.termId != null)
                 this.$eventBusSearch.setTerm(this.termId, this.taxonomy);
-            if (this.defaultOrder != undefined)
+            if (this.defaultOrder != undefined) {
                 this.$eventBusSearch.setDefaultOrder(this.defaultOrder);
+
+                if (!this.$route.query.order)
+                    this.$eventBusSearch.setOrder(this.defaultOrder);
+            }
             if (this.defaultOrderBy != undefined) {
-                this.$eventBusSearch.setDefaultOrderBy(this.defaultOrderBy);
+                if (this.defaultOrderByMeta || this.defaultOrderByType) {
+                    
+                    let orderByObject = { orderby: this.defaultOrderBy }
+                    
+                    if (this.defaultOrderByMeta)
+                        orderByObject['metakey'] = this.defaultOrderByMeta;
+                    
+                    if (this.defaultOrderByType)
+                        orderByObject['metatype'] = this.defaultOrderByType;
+                    
+                    this.$eventBusSearch.setDefaultOrderBy(orderByObject);
+
+                    if (!this.$route.query.orderby)
+                        this.$eventBusSearch.setOrderBy(orderByObject);
+                
+                } else {                    
+                    this.$eventBusSearch.setDefaultOrderBy(this.defaultOrderBy);
+
+                    if (!this.$route.query.orderby)
+                        this.$eventBusSearch.setOrderBy(this.defaultOrderBy);
+                }
             }
             
             this.$eventBusSearch.updateStoreFromURL();
@@ -999,6 +1025,7 @@
         },
         methods: {
             ...mapGetters('collection', [
+                'getCollection',
                 'getItems',
                 'getItemsListTemplate'
             ]),

--- a/src/views/gutenberg-blocks/blocks/faceted-search/theme.js
+++ b/src/views/gutenberg-blocks/blocks/faceted-search/theme.js
@@ -234,7 +234,7 @@ export default (element) => {
                         this.defaultOrderByMeta = this.$el.attributes['default-orderby-meta'].value;
                     if (this.$el.attributes['default-orderby-type'] != undefined)
                         this.defaultOrderByType = this.maybeConvertFromJSON(this.$el.attributes['default-orderby-type'].value);
-                    
+
                     // Options related to hidding elements
                     if (this.$el.attributes['hide-filters'] != undefined)
                         this.hideFilters = this.isParameterTrue('hide-filters');

--- a/src/views/gutenberg-blocks/blocks/faceted-search/theme.js
+++ b/src/views/gutenberg-blocks/blocks/faceted-search/theme.js
@@ -173,6 +173,8 @@ export default (element) => {
                     defaultViewMode: '',
                     defaultOrder: 'ASC',
                     defaultOrderBy: 'date',
+                    defaultOrderByMeta: '',
+                    defaultOrderByType: '',
                     isForcedViewMode: false,
                     enabledViewModes: {},
                     defaultItemsPerPage: '',
@@ -228,6 +230,10 @@ export default (element) => {
                         this.defaultOrder = this.$el.attributes['default-order'].value;
                     if (this.$el.attributes['default-orderby'] != undefined)
                         this.defaultOrderBy = this.maybeConvertFromJSON(this.$el.attributes['default-orderby'].value);
+                    if (this.$el.attributes['default-orderby-meta'] != undefined)
+                        this.defaultOrderByMeta = this.$el.attributes['default-orderby-meta'].value;
+                    if (this.$el.attributes['default-orderby-type'] != undefined)
+                        this.defaultOrderByType = this.maybeConvertFromJSON(this.$el.attributes['default-orderby-type'].value);
                     
                     // Options related to hidding elements
                     if (this.$el.attributes['hide-filters'] != undefined)

--- a/src/views/gutenberg-blocks/blocks/faceted-search/theme.vue
+++ b/src/views/gutenberg-blocks/blocks/faceted-search/theme.vue
@@ -9,6 +9,8 @@
             :is-forced-view-mode="$root.isForcedViewMode"
             :default-order="$root.defaultOrder"
             :default-order-by="$root.defaultOrderBy"
+            :default-order-by-meta="$root.defaultOrderByMeta"
+            :default-order-by-type="$root.defaultOrderByType"
             :default-items-per-page="$root.defaultItemsPerPage"
             :hide-filters="$root.hideFilters ? $root.hideFilters : false"
             :hide-hide-filters-button="$root.hideHideFiltersButton ? $root.hideHideFiltersButton : false"


### PR DESCRIPTION
This feature adds ASC, DESC and Title, Date options to order and orderby options in the faceted search block when using Term o Repository level lists generated from the faceted search block. It does not lists repository metadata yet. For Collection Items list, the selection modal now saves the option preset in the collection settings. Only order can be changed, as orderby is inherited from the collection.