### PR TITLE
Allow metadata fetch() method without arguments

### DIFF
--- a/src/classes/repositories/class-tainacan-metadata.php
+++ b/src/classes/repositories/class-tainacan-metadata.php
@@ -344,7 +344,7 @@ class Metadata extends Repository {
 	 * @return Entities\Metadatum|\WP_Query|Array an instance of wp query OR array of entities;
 	 * @throws \Exception
 	 */
-	public function fetch( $args, $output = null ) {
+	public function fetch( $args = [], $output = null ) {
 
 		if ( is_numeric( $args ) ) {
 			$existing_post = get_post( $args );


### PR DESCRIPTION
In order to keep consistent with Collection, Items, Filters and others, Metadata fetch method should allow to be called without arguments.