### PR TITLE
feat: translated field labels of INBCM mappers to Portuguese

### DIFF
--- a/src/classes/mappers/class-tainacan-inbcm-archive.php
+++ b/src/classes/mappers/class-tainacan-inbcm-archive.php
@@ -14,53 +14,53 @@ class Inbcm_Archive extends Mapper {
 		/* Metadata should be set here to allow translable labels */ 
 		$this->metadata = [
 			'inbcm:codRef' => [
-				'label' => __( 'Reference Code', 'tainacan')
+				'label' =>('Cód. de Referência')
 			],
 			'inbcm:titulo' => [
-				'label' => __( 'Title', 'tainacan'),
+				'label' => ('Título'),
                 'core_metadatum' => 'title'
 			],
 			'inbcm:data' => [
-				'label' => __( 'Date', 'tainacan'),
+				'label' => ('Data'),
 			],
 			'inbcm:nivelDescricao' => [
-				'label' => __( 'Level of Description', 'tainacan')
+				'label' => ( 'Nível de Descrição')
 			],
 			'inbcm:dimSuporte' => [
-				'label' => __( 'Extent and Medium', 'tainacan'),
+				'label' => ('Dimensão e suporte'),
 			],
 			'inbcm:nomeProdutor' => [
-				'label' => __( 'Name of Creator', 'tainacan')
+				'label' => ('Nome do Produtor')
 			],
 			'inbcm:biografia' => [
-				'label' => __( 'Administrative History / Biography', 'tainacan')
+				'label' => ('História administrativa / Biografia')
 			],
 			'inbcm:historiaArquivistica' => [
-				'label' => __( 'Archival History', 'tainacan')
+				'label' => ('História Arquivística')
 			],
 			'inbcm:procedencia' => [
-				'label' => __( 'Provenance', 'tainacan')
+				'label' => ('Procedência')
 			],
 			'inbcm:conteudo' => [
-				'label' => __( 'Scope and Content', 'tainacan')
+				'label' => ('Âmbito e Conteúdo')
 			],
 			'inbcm:arranjo' => [
-				'label' => __( 'System of Arrangement', 'tainacan')
+				'label' => ('Sistema de Arranjo')
 			],
 			'inbcm:reproducao' => [
-				'label' => __( 'Conditions of Reproduction', 'tainacan')
+				'label' => ('Condições de Reprodução')
 			],
 			'inbcm:originais' => [
-				'label' => __( 'Existence and Location of Originals', 'tainacan')
+				'label' => ('Existência e Localização dos Originais')
 			],
 			'inbcm:conservacao' => [
-				'label' => __( 'Existence and State of Conservation of Originals', 'tainacan')
+				'label' => ('Notas sobre conservação')
 			],
 			'inbcm:indexacao' => [
-				'label' => __( 'Access Points and Subject Indexing', 'tainacan')
+				'label' => ('Pontos de acesso e indexação de assuntos')
 			],
 			'inbcm:midias' => [
-				'label' => __( 'Related Media', 'tainacan')
+				'label' => ('Mídias Relacionadas')
 			]
 		];
 	}

--- a/src/classes/mappers/class-tainacan-inbcm-bibliographic.php
+++ b/src/classes/mappers/class-tainacan-inbcm-bibliographic.php
@@ -14,62 +14,62 @@ class Inbcm_Bibliographic extends Mapper {
 		/* Metadata should be set here to allow translable labels */ 
 		$this->metadata = [
 			'inbcm:numRegistro' => [
-				'label' => __( 'Reference Number', 'tainacan')
+				'label' => ('Nº de Registro')
 			],
 			'inbcm:outrosNum' => [
-				'label' => __( 'Other Numbers', 'tainacan')
+				'label' => ('Outros Números')
 			],
 			'inbcm:situacao' => [
-				'label' => __( 'Condition/Status', 'tainacan'),
+				'label' => ('Situação'),
 			],
 			'inbcm:titulo' => [
-				'label' => __( 'Title', 'tainacan'),
+				'label' => ('Título'),
                 'core_metadatum' => 'title'
 			],
 			'inbcm:tipo' => [
-				'label' => __( 'Type', 'tainacan'),
+				'label' => ('Tipo'),
 			],
 			'inbcm:idenResponsabilidade' => [
-				'label' => __( 'Statement of Responsibility', 'tainacan')
+				'label' => ('Identificação de responsabilidade')
 			],
 			'inbcm:localProd' => [
-				'label' => __( 'Place of Production', 'tainacan')
+				'label' => ('Local de produção')
 			],
 			'inbcm:editora' => [
-				'label' => __( 'Publisher', 'tainacan')
+				'label' => ('Editora')
 			],
 			'inbcm:dataProd' => [
-				'label' => __( 'Date of Production', 'tainacan')
+				'label' => ('Data de Produção')
 			],
 			'inbcm:dimFisica' => [
-				'label' => __( 'Physical Dimensions', 'tainacan')
+				'label' => ('Dimensão física')
 			],
 			'inbcm:matTecnica' => [
-				'label' => __( 'Material / Technique', 'tainacan')
+				'label' => ('Material / Técnica')
 			],
 			'inbcm:encadernacao' => [
-				'label' => __( 'Binding', 'tainacan')
+				'label' => ('Encadernação')
 			],
 			'inbcm:resumoDes' => [
-				'label' => __( 'Descriptive Summary', 'tainacan')
+				'label' => ('Resumo Descritivo')
 			],
 			'inbcm:conservacao' => [
-				'label' => __( 'Conservation Status', 'tainacan')
+				'label' => ('Estado de Conservação')
 			],
 			'inbcm:assuntoPrincipal' => [
-				'label' => __( 'Main Subject', 'tainacan')
+				'label' => ('Assunto Principal')
 			],
 			'inbcm:assuntoCronologico' => [
-				'label' => __( 'Chronological Subject', 'tainacan')
+				'label' => ('Assunto Cronológico')
 			],
 			'inbcm:assuntoGeo' => [
-				'label' => __( 'Geographical Subject', 'tainacan')
+				'label' => ('Assunto Geográfico')
 			],
 			'inbcm:condReproducao' => [
-				'label' => __( 'Reproduction Conditions', 'tainacan')
+				'label' => ('Condições de Reprodução')
 			],
 			'inbcm:midias' => [
-				'label' => __( 'Related Media', 'tainacan')
+				'label' => ('Mídias Relacionadas')
 			]
 		];
 	}

--- a/src/classes/mappers/class-tainacan-inbcm-museological.php
+++ b/src/classes/mappers/class-tainacan-inbcm-museological.php
@@ -12,50 +12,50 @@ class Inbcm_Museological extends Mapper {
 
 		$this->metadata = [
 			'inbcm:numRegistro' => [
-				'label' => __( 'Registration Number', 'tainacan' )
+				'label' => ('Nº de Registro')
 			],
 			'inbcm:outrosNum' => [
-				'label' => __( 'Other Numbers', 'tainacan' )
+				'label' => ('Outros Números')
 			],
 			'inbcm:situacao' => [
-				'label' => __( 'Condition/Status', 'tainacan' )
+				'label' => ('Situação')
 			],
 			'inbcm:denominacao' => [
-				'label' => __( 'Denomination', 'tainacan' )
+				'label' => ('Denominação')
 			],
 			'inbcm:titulo' => [
-				'label' => __( 'Title', 'tainacan' ),
+				'label' => ('Título'),
                 'core_metadatum' => 'title'
 			],
 			'inbcm:autor' => [
-				'label' => __( 'Author', 'tainacan' )
+				'label' => ('Autor')
 			],
 			'inbcm:classificacao' => [
-				'label' => __( 'Classification', 'tainacan' )
+				'label' => ('Classificação')
 			],
 			'inbcm:resumoDes' => [
-				'label' => __( 'Descriptive Summary', 'tainacan' )
+				'label' => ('Resumo Descritivo')
 			],
 			'inbcm:dimensoes' => [
-				'label' => __( 'Dimensions', 'tainacan' )
+				'label' => ('Dimensões')
 			],
 			'inbcm:matTecnica' => [
-				'label' => __( 'Material/Technique', 'tainacan' )
+				'label' => ('Material/Técnica')
 			],
 			'inbcm:conservacao' => [
-				'label' => __( 'Conservation Status', 'tainacan' )
+				'label' => ('Estado de Conservação')
 			],
 			'inbcm:localProd' => [
-				'label' => __( 'Place of Production', 'tainacan' )
+				'label' => ('Local de Produção')
 			],
 			'inbcm:dataProd' => [
-				'label' => __( 'Date of Production', 'tainacan' )
+				'label' => ('Data de Produção')
 			],
 			'inbcm:condReproducao' => [
-				'label' => __( 'Reproduction Conditions', 'tainacan' )
+				'label' => ('Condições de Reprodução')
 			],
 			'inbcm:midias' => [
-				'label' => __( 'Related Media', 'tainacan' )
+				'label' => ('Mídias Relacionadas')
 			]
 		];
 	}


### PR DESCRIPTION
**Description**

- This PR translates the labels of the INBCM mappers into Portuguese, aiming to improve interface clarity and usability for Portuguese-speaking users.

**What was done**

- Translated the labels in the mappers related to INBCM
- No functional changes were made to the behavior of the mappers

**Notes**
Translations were made based on the technical terminology used in the project.

Fixes #953 
