### PR TITLE
Issue 892 - Blueprint Creation

### DIFF
--- a/blueprint.json
+++ b/blueprint.json
@@ -18,6 +18,11 @@
     "extraLibraries": [
         "wp-cli"
     ],
+    "siteOptions": {
+        "timezone_string": "America/Sao_Paulo",
+        "date_format": "d/m/Y",
+        "time_format": "H:i"
+    },
     "plugins": [
         {
             "resource": "wordpress.org/plugins",

--- a/blueprint.json
+++ b/blueprint.json
@@ -38,7 +38,7 @@
         },
         {
             "step": "wp-cli",
-            "command": "plugin uninstall hello-dolly --deactivate"
+            "command": "wp plugin is-active hello-dolly && wp plugin deactivate hello-dolly && wp plugin delete hello-dolly"
         }
     ]
 }

--- a/blueprint.json
+++ b/blueprint.json
@@ -25,9 +25,9 @@
         }
     ],
     "constants": {
-		"WP_DEBUG": true,
-        "WP_DEBUG_DISPLAY": true,
-        "WP_DEBUG_LOG": true
+		"WP_DEBUG": false,
+        "WP_DEBUG_DISPLAY": false,
+        "WP_DEBUG_LOG": false
 	},
     "steps": [
         {

--- a/blueprint.json
+++ b/blueprint.json
@@ -1,0 +1,27 @@
+{
+	"$schema": "https://playground.wordpress.net/blueprint-schema.json",
+    "landingPage": "/wp-admin/",
+    "login": true,
+    "preferredVersions": {
+        "php": "8.4",
+        "wp": "6.8"
+    },
+    "siteOptions": {
+        "blogname": "Tainacan Demonstration"
+    },
+    "meta": {
+        "title": "Tainacan Demonstration Blueprint",
+        "description": "Provides a pre-configured demonstration environment for the Tainacan plugin. It automates the setup of collections, items, metadatas and filters within a WordPress Playground instance, allowing users to quickly experience the plugin's features without a full installation.",
+        "author": "FabricioDeQueiroz, CaioSulz and harry-cmartin"
+    },
+    "features": {
+        "intl": true,
+        "networking": true
+    },
+    "plugins": [
+        {
+            "resource": "wordpress.org/plugins",
+            "slug": "tainacan"
+        }
+    ]
+}

--- a/blueprint.json
+++ b/blueprint.json
@@ -1,13 +1,10 @@
 {
 	"$schema": "https://playground.wordpress.net/blueprint-schema.json",
-    "landingPage": "/wp-admin/",
+    "landingPage": "/wp-admin/admin.php?page=tainacan_admin#/home",
     "login": true,
     "preferredVersions": {
         "php": "8.4",
         "wp": "6.8"
-    },
-    "siteOptions": {
-        "blogname": "Tainacan Demonstration"
     },
     "meta": {
         "title": "Tainacan Demonstration Blueprint",
@@ -18,10 +15,30 @@
         "intl": true,
         "networking": true
     },
+    "extraLibraries": [
+        "wp-cli"
+    ],
     "plugins": [
         {
             "resource": "wordpress.org/plugins",
             "slug": "tainacan"
+        }
+    ],
+    "steps": [
+        {
+            "step": "setSiteLanguage",
+            "language": "pt_BR"
+        },
+        {
+            "step": "setSiteOptions",
+            "options": {
+                "blogname": "Tainacan Demonstration",
+                "permalink_structure": "/%postname%/"
+            }
+        },
+        {
+            "step": "wp-cli",
+            "command": "plugin uninstall hello-dolly --deactivate"
         }
     ]
 }

--- a/blueprint.json
+++ b/blueprint.json
@@ -24,10 +24,19 @@
             "slug": "tainacan"
         }
     ],
+    "constants": {
+		"WP_DEBUG": true,
+        "WP_DEBUG_DISPLAY": true,
+        "WP_DEBUG_LOG": true
+	},
     "steps": [
         {
-            "step": "setSiteLanguage",
-            "language": "pt_BR"
+            "step": "wp-cli",
+            "command": "wp language core install pt_BR"
+        },
+        {
+            "step": "wp-cli",
+            "command": "wp site switch-language pt_BR"
         },
         {
             "step": "setSiteOptions",
@@ -35,10 +44,6 @@
                 "blogname": "Tainacan Demonstration",
                 "permalink_structure": "/%postname%/"
             }
-        },
-        {
-            "step": "wp-cli",
-            "command": "wp plugin is-active hello-dolly && wp plugin deactivate hello-dolly && wp plugin delete hello-dolly"
         }
     ]
 }


### PR DESCRIPTION
## Blueprint Creation

- Issue #892 (No closing clause, because it can still be improved)

- Blueprint for the Tainacan plugin.
- Opens directly in the plugin screen.
- Sets siteOptions permalink to postname.

- Does not "populate" the plugin.

- Current Blueprint Link: [blueprint-link](https://playground.wordpress.net/?blueprint-url=https://raw.githubusercontent.com/Tainacan-GCES-2025-1/tainacan/f5f0c95eda52a408e1b544caad2e18ddf302ceab/blueprint.json) (the link must reference the .json file).