### PR TITLE
Add option to disable query parameters in item links

### DIFF
--- a/src/classes/theme-helper/class-tainacan-theme-helper.php
+++ b/src/classes/theme-helper/class-tainacan-theme-helper.php
@@ -1129,6 +1129,16 @@ class Theme_Helper {
 	}
 
 	/**
+	 * Get whether query parameters should be included in item links from faceted search.
+	 * This can be tweaked in the settings page.
+	 * 
+	 * @return bool Whether to include query parameters in item links
+	 */
+	public function get_enable_item_link_query_params() {
+		return apply_filters( 'tainacan-enable-item-link-query-params-for-themes', get_option( 'tainacan_option_enable_item_link_query_params', true ) );
+	}
+
+	/**
 	 * When visiting a collection archive or single, returns the current collection id
 	 *
 	 * @uses get_post_type() WordPress function, which looks for the global $wp_query variable

--- a/src/views/gutenberg-blocks/blocks/faceted-search/theme-search/js/view-modes-mixin.js
+++ b/src/views/gutenberg-blocks/blocks/faceted-search/theme-search/js/view-modes-mixin.js
@@ -78,7 +78,12 @@ export const viewModesMixin = {
             return '';
         },
         getItemLink(itemUrl, index) {
-            if (this.queries) {
+            // Check if query parameters should be included based on the setting
+            const enableQueryParams = (typeof tainacan_blocks !== 'undefined' && tainacan_blocks.enable_item_link_query_params !== undefined) 
+                ? tainacan_blocks.enable_item_link_query_params 
+                : true; // Default to true to maintain current behavior
+            
+            if (this.queries && enableQueryParams) {
                 // Inserts information necessary for item by item navigation on single pages
                 this.queries['pos'] = ((this.queries['paged'] - 1) * this.queries['perpage']) + index;
                 if ( isNaN(Number(this.queries['pos'])) )

--- a/src/views/gutenberg-blocks/class-tainacan-gutenberg-block.php
+++ b/src/views/gutenberg-blocks/class-tainacan-gutenberg-block.php
@@ -249,7 +249,8 @@ function tainacan_blocks_get_plugin_js_settings(){
 		'enabled_view_modes' => \Tainacan\Theme_Helper::get_instance()->get_enabled_view_modes(),
 		'default_view_mode' => \Tainacan\Theme_Helper::get_instance()->get_default_view_mode(),
 		'default_order' => \Tainacan\Theme_Helper::get_instance()->get_default_order(),
-		'default_orderby' => \Tainacan\Theme_Helper::get_instance()->get_default_orderby()
+		'default_orderby' => \Tainacan\Theme_Helper::get_instance()->get_default_orderby(),
+		'enable_item_link_query_params' => \Tainacan\Theme_Helper::get_instance()->get_enable_item_link_query_params()
 	];
 	
 	return $settings;

--- a/src/views/settings/class-tainacan-settings.php
+++ b/src/views/settings/class-tainacan-settings.php
@@ -303,6 +303,18 @@ class Settings extends Pages {
 			'default' => isset($view_modes['default_order']) ? $view_modes['default_order'] : 'DESC'
 		) );
 
+		$this->create_tainacan_setting( array(
+			'id' => 'enable_item_link_query_params',
+			'section' => 'tainacan_settings_items_list_defaults',
+			'title' => __( 'Item link query parameters', 'tainacan' ),
+			'label' => __( 'Include query parameters in item links from faceted search', 'tainacan' ),
+			'description' => __( 'Enable this option to pass query parameters (filters, sorting, pagination) in item links. This allows navigation between items while preserving the search context. If disabled, item links will be cleaner but next/previous navigation won\'t.know about any filtering and will be sorted by the creation date.', 'tainacan' ),
+			'type' => 'boolean',
+			'input_type' => 'checkbox',
+			'sanitize_callback' => 'rest_sanitize_boolean',
+			'default' => true
+		) );
+
 		/**
 		 * Google reCAPTCHA -----------------------------------------------------
 		 */


### PR DESCRIPTION
Implements issue #857 by adding a new setting that allows users to disable the inclusion of query parameters (source_list, pos, ref, etc.) in item links from faceted search results.

Changes:
- Add 'enable_item_link_query_params' setting in Settings page under 'Default theme items list options' section
- Store setting using WordPress option with boolean type and rest_sanitize_boolean sanitizer
- Pass setting to JavaScript via tainacan_blocks global variable
- Add wrapper function get_enable_item_link_query_params() in Theme_Helper class
- Update view-modes-mixin.js to conditionally add query parameters based on the setting

When disabled, item links will be cleaner (better for sharing), but next/previous navigation between items will follow  WordPress default behaviour. Default is enabled (true) to maintain current behavior.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds a new setting that controls whether faceted-search query parameters are appended to item links and updates frontend logic to respect it.
> 
> - **Settings**:
>   - Add boolean `tainacan_option_enable_item_link_query_params` under "Default theme items list options" with label and description.
> - **Theme Helper (PHP)**:
>   - New getter `get_enable_item_link_query_params()` returning filtered option.
> - **Blocks localization (PHP → JS)**:
>   - Expose `enable_item_link_query_params` via `tainacan_blocks` in `tainacan_blocks_get_plugin_js_settings()`.
> - **Frontend (JS)**:
>   - Update `getItemLink()` in `view-modes-mixin.js` to conditionally append query params (`pos`, `source_list`, `source_entity_id`, `ref`, etc.) based on `tainacan_blocks.enable_item_link_query_params`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 665fdb39c8207ca7d895429534e46dc5ca7986a9. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->