### PR TITLE
Adds NOT EXISTS and EXISTS operators to Advanced Search. #720.

### DIFF
--- a/src/views/admin/components/search/advanced-search.vue
+++ b/src/views/admin/components/search/advanced-search.vue
@@ -100,7 +100,7 @@
 
                 <!-- Inputs -->
                 <b-field class="column is-half is-10-mobile">
-                    <template v-if="searchCriterion.type == 'metaquery' && advancedSearchQuery.metaquery[searchCriterion.index]">
+                    <template v-if="searchCriterion.type == 'metaquery' && advancedSearchQuery.metaquery[searchCriterion.index] && advancedSearchQuery.metaquery[searchCriterion.index].compare != 'NOT EXISTS' && advancedSearchQuery.metaquery[searchCriterion.index].compare != 'EXISTS'">
                         <b-input
                                 v-if="getAdvancedSearchQueryCriterionMetadataType(searchCriterion.index) == 'int' || getAdvancedSearchQueryCriterionMetadataType(searchCriterion.index) == 'float'"
                                 type="number"
@@ -129,7 +129,7 @@
                             />
                     </template>
                     <b-input
-                            v-else-if="searchCriterion.type == 'taxquery' && advancedSearchQuery.taxquery[searchCriterion.index]"
+                            v-else-if="searchCriterion.type == 'taxquery' && advancedSearchQuery.taxquery[searchCriterion.index] && advancedSearchQuery.taxquery[searchCriterion.index].operator != 'NOT EXISTS' && advancedSearchQuery.taxquery[searchCriterion.index].operator != 'EXISTS'"
                             :model-value="advancedSearchQuery.taxquery[searchCriterion.index].terms"
                             type="text"
                             :placeholder="$i18n.get('label_string_to_search_for')"
@@ -261,16 +261,22 @@
                     '<': this.$i18n.get('less_than'),
                     '>=': this.$i18n.get('greater_than_or_equal_to'),
                     '<=': this.$i18n.get('less_than_or_equal_to'),
+                    'NOT EXISTS': this.$i18n.get('has_no_value'),
+                    'EXISTS': this.$i18n.get('has_value'),
                 },
                 metaqueryOperatorsRegular: {
                     '=': this.$i18n.get('is_equal_to'),
                     '!=': this.$i18n.get('is_not_equal_to'),
                     'LIKE': this.$i18n.get('contains'),
                     'NOT LIKE': this.$i18n.get('not_contains'),
+                    'NOT EXISTS': this.$i18n.get('has_no_value'),
+                    'EXISTS': this.$i18n.get('has_value'),
                 },
                 taxqueryOperators: {
                     'LIKE': this.$i18n.get('contains'),
-                    'NOT LIKE': this.$i18n.get('not_contains')
+                    'NOT LIKE': this.$i18n.get('not_contains'),
+                    'NOT EXISTS': this.$i18n.get('has_no_value'),
+                    'EXISTS': this.$i18n.get('has_value'),
                 },
                 searchCriteria: [],
                 advancedSearchQuery: {
@@ -576,10 +582,18 @@
                 if (!comparator)
                     return;
 
-                if (searchCriterion.type == 'metaquery' && this.advancedSearchQuery.metaquery[searchCriterion.index])
+                if (searchCriterion.type == 'metaquery' && this.advancedSearchQuery.metaquery[searchCriterion.index]) {
                     Object.assign(this.advancedSearchQuery.metaquery[searchCriterion.index], { 'compare': comparator });
-                else if (searchCriterion.type == 'taxquery' && this.advancedSearchQuery.taxquery[searchCriterion.index])
+
+                    if (comparator == 'NOT EXISTS' || comparator == 'EXISTS')
+                        delete this.advancedSearchQuery.metaquery[searchCriterion.index].value;
+                    
+                } else if (searchCriterion.type == 'taxquery' && this.advancedSearchQuery.taxquery[searchCriterion.index]) {
                     Object.assign(this.advancedSearchQuery.taxquery[searchCriterion.index], { 'operator': comparator });
+
+                    if (comparator == 'NOT EXISTS' || comparator == 'EXISTS')
+                        delete this.advancedSearchQuery.taxquery[searchCriterion.index].terms;
+                }
 
                 this.hasUpdatedSearch = true;
             },
@@ -598,13 +612,13 @@
                     delete this.advancedSearchQuery.taxquery.relation;
 
                 // Convert date values to a format (ISO_8601) that will match in database
-                if (Object.keys(this.advancedSearchQuery.metaquery).length > 0) {
+                if ( Object.keys(this.advancedSearchQuery.metaquery).length > 0 ) {
 
                     for (let metaquery in this.advancedSearchQuery.metaquery) {
                         if (this.getAdvancedSearchQueryCriterionMetadataType(metaquery) == 'date') {
                             let value = this.advancedSearchQuery.metaquery[metaquery].value;
                             
-                            if (value.includes('/'))
+                            if (value != null && value != undefined && value.includes('/'))
                                 Object.assign(this.advancedSearchQuery.metaquery[metaquery], { 'value': this.convertDateToMatchInDB(value) });
                         }
                     }
@@ -618,13 +632,13 @@
                 if ( Object.prototype.hasOwnProperty.call(this.advancedSearchQuery, 'relation') && Object.keys(this.advancedSearchQuery).length <= 3)
                     delete this.advancedSearchQuery.relation;
                 
-                if (Object.keys(this.advancedSearchQuery.metaquery).length > 0) {
+                if ( Object.keys(this.advancedSearchQuery.metaquery).length > 0 ) {
 
                     for (let metaquery in this.advancedSearchQuery.metaquery) {
                         if (this.getAdvancedSearchQueryCriterionMetadataType(metaquery) == 'date') {
                             let value = this.advancedSearchQuery.metaquery[metaquery].value;
                             
-                            if (value.includes('-'))
+                            if (value != null && value != undefined && value.includes('-'))
                                 Object.assign(this.advancedSearchQuery.metaquery[metaquery], { 'value': this.parseValidDateToNavigatorLanguage(value) });
                         }
                     }

--- a/src/views/tainacan-i18n.php
+++ b/src/views/tainacan-i18n.php
@@ -17,6 +17,8 @@ return apply_filters( 'tainacan-i18n', [
 	'after'		                                     => __( 'After', 'tainacan' ),
 	'before_or_on_day'		                         => __( 'Before (inclusive)', 'tainacan' ),
 	'after_or_on_day'                          		 => __( 'After (inclusive)', 'tainacan' ),
+	'has_value'                                      => __( 'Has value', 'tainacan' ),
+	'has_no_value'                                   => __( 'Has no value', 'tainacan' ),
 
 	// Tainacan common terms
 	'repository'                                     => __( 'Repository', 'tainacan' ),


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Adds EXISTS/NOT EXISTS operators for `metaquery` and `taxquery`, updating UI behavior, query building, and i18n labels.
> 
> - **Advanced Search UI (`src/views/admin/components/search/advanced-search.vue`)**:
>   - Add `EXISTS`/`NOT EXISTS` comparators for `metaquery` and `taxquery` (operator lists and comparator handling).
>   - Hide/disable value inputs when `EXISTS`/`NOT EXISTS` is selected; remove `value`/`terms` from query accordingly.
>   - Improve date handling with null/undefined guards during ISO conversion and parsing.
>   - Maintain relation logic for combined queries.
> - **Internationalization (`src/views/tainacan-i18n.php`)**:
>   - Add labels `has_value` and `has_no_value` for new comparators.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit cb5d1a4bd3a9382df53fefaf59d6a013944a58cb. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->