### PR TITLE
Creates section for disabling gutenberg blocks and variations on settings screen #879

### DIFF
--- a/src/classes/tainacan-creator.php
+++ b/src/classes/tainacan-creator.php
@@ -211,7 +211,7 @@ require_once(__DIR__ . '/theme-helper/class-tainacan-theme-helper.php');
 require_once(__DIR__ . '/theme-helper/template-tags.php');
 \Tainacan\Theme_Helper::get_instance();
 
-require_once(__DIR__ . '/../views/gutenberg-blocks/class-tainacan-gutenberg-block.php');
-\Tainacan\Gutenberg_Block::get_instance();
+require_once(__DIR__ . '/../views/gutenberg-blocks/class-tainacan-gutenberg-blocks.php');
+\Tainacan\Gutenberg_Blocks::get_instance();
 
 include_once('tainacan-loaders.php');

--- a/src/classes/tainacan-creator.php
+++ b/src/classes/tainacan-creator.php
@@ -212,5 +212,6 @@ require_once(__DIR__ . '/theme-helper/template-tags.php');
 \Tainacan\Theme_Helper::get_instance();
 
 require_once(__DIR__ . '/../views/gutenberg-blocks/class-tainacan-gutenberg-block.php');
+\Tainacan\Gutenberg_Block::get_instance();
 
 include_once('tainacan-loaders.php');

--- a/src/views/gutenberg-blocks/class-tainacan-gutenberg-block.php
+++ b/src/views/gutenberg-blocks/class-tainacan-gutenberg-block.php
@@ -1,404 +1,463 @@
 <?php
 
+namespace Tainacan;
+
 defined( 'ABSPATH' ) or die( 'No script kiddies please!' );
 
-// Slugs and options for the Tainacan Blocks.
-const TAINACAN_BLOCKS = [
-	'items-list' => [],
-	'collections-list' => [],
-	'search-bar' => [],
-	'facets-list' => [ 'set_script_translations' => true ],
-	'dynamic-items-list' => [ 'set_script_translations' => true ],
-	'carousel-items-list' => [ 'set_script_translations' => true ],
-	'carousel-terms-list' => [ 'set_script_translations' => true ],
-	'carousel-collections-list' => [ 'set_script_translations' => true ],
-	'related-items-list' => [ 'render_callback' => 'tainacan_blocks_render_related_items_list', 'keep_inner_blocks' => true ],
-	'terms-list' => [],
-	'faceted-search' => [],
-	'item-submission-form' => [],
-	'item-gallery' => [  'set_script_translations' => true, 'render_callback' => 'tainacan_blocks_render_item_gallery' ],
-	'item-metadata-sections' => ['render_callback' => 'tainacan_blocks_render_metadata_sections'],
-	'item-metadata-section' => ['render_callback' => 'tainacan_blocks_render_metadata_section'],
-	'item-metadata' => ['render_callback' => 'tainacan_blocks_render_item_metadata'],
-	'item-metadatum' => ['render_callback' => 'tainacan_blocks_render_item_metadatum'],
-	'geocoordinate-item-metadatum' => ['render_callback' => 'tainacan_blocks_render_geocoordinate_item_metadatum'],
-	'metadata-section-name' => [],
-	'metadata-section-description' => [],
-	'items-gallery' => [ 'set_script_translations' => true, 'render_callback' => 'tainacan_blocks_render_items_gallery' ],
-];
-
-// Lets do this!
-tainacan_blocks_initialize();
-
-/** 
- * Initialize the Gutenberg Blocks logic, only if possible
+/**
+ * Handles registration of Tainacan Gutenberg blocks and Query loop variations.
+ * Not a page; provides block list and labels for Settings and filters registration by options.
  */
-function tainacan_blocks_initialize() {
+class Gutenberg_Block {
+	use \Tainacan\Traits\Singleton_Instance;
 
-	// Via Gutenberg filters, we create the Tainacan category
-	if ( class_exists('WP_Block_Editor_Context') ) { // Introduced WP 5.8
-		add_filter( 'block_categories_all', 'tainacan_blocks_register_categories', 10, 2 );
-	} else {
-		add_filter( 'block_categories', 'tainacan_blocks_register_categories', 10, 2 );
-	}
+	/**
+	 * Slugs and options for the Tainacan Blocks.
+	 *
+	 * @var array<string, array>
+	 */
+	public static $blocks = [
+		'items-list' => [],
+		'collections-list' => [],
+		'search-bar' => [],
+		'facets-list' => [ 'set_script_translations' => true ],
+		'dynamic-items-list' => [ 'set_script_translations' => true ],
+		'carousel-items-list' => [ 'set_script_translations' => true ],
+		'carousel-terms-list' => [ 'set_script_translations' => true ],
+		'carousel-collections-list' => [ 'set_script_translations' => true ],
+		'related-items-list' => [ 'render_callback' => 'tainacan_blocks_render_related_items_list', 'keep_inner_blocks' => true ],
+		'terms-list' => [],
+		'faceted-search' => [],
+		'item-submission-form' => [],
+		'item-gallery' => [ 'set_script_translations' => true, 'render_callback' => 'tainacan_blocks_render_item_gallery' ],
+		'item-metadata-sections' => [ 'render_callback' => 'tainacan_blocks_render_metadata_sections' ],
+		'item-metadata-section' => [ 'render_callback' => 'tainacan_blocks_render_metadata_section' ],
+		'item-metadata' => [ 'render_callback' => 'tainacan_blocks_render_item_metadata' ],
+		'item-metadatum' => [ 'render_callback' => 'tainacan_blocks_render_item_metadatum' ],
+		'geocoordinate-item-metadatum' => [ 'render_callback' => 'tainacan_blocks_render_geocoordinate_item_metadatum' ],
+		'metadata-section-name' => [],
+		'metadata-section-description' => [],
+		'items-gallery' => [ 'set_script_translations' => true, 'render_callback' => 'tainacan_blocks_render_items_gallery' ],
+	];
 
-	// On the theme side, all we need is the common scripts, 
-	// that handle dynamically the imports using conditioner.js
-	if ( !is_admin() ) {
-		add_action( 'init', 'tainacan_blocks_add_common_theme_scripts', 90 );
-		add_action( 'init', 'tainacan_blocks_get_common_theme_styles', 90 );
-	}
+	/**
+	 * Plugin blocks directory (without trailing slash).
+	 *
+	 * @var string
+	 */
+	protected $blocks_dir;
 
-	// On the admin side, we need the blocks registered and their assets (editor-side)
-	// The reason why we don't use admin_init here is because server side blocks
-	// need to be registered whithin the init
-	add_action( 'init', 'tainacan_blocks_register_and_enqueue_all_blocks', 11 );
-
-	// Adicionally, we also register the Tainacan react components that may be used by
-	// block editor scripts and plugin extenders
-	if ( is_admin() ) {
-		add_action( 'init', 'tainacan_blocks_register_react_components', 12 );
-	}
-}
-
-/** 
- * Registers the Tainacan category on the blocks inserter
- */
-function tainacan_blocks_register_categories($categories, $editor_context) {
-	return array_merge(
-		$categories,
-		array(
-			array(
-				'slug' => 'tainacan-blocks',
-				'title' => __( 'Tainacan Blocks', 'tainacan' ),
-			),
-			array(
-				'slug' => 'tainacan-blocks-variations',
-				'title' => __( 'Tainacan Query Loop Variations', 'tainacan' ),
-			),
-		)
-	);
-}
-
-/** 
- * Calls the routines responsible for Registering the global style, category and 
- * both 'generic' and 'special' blocks
- */
-function tainacan_blocks_register_and_enqueue_all_blocks() {
-	// Only needed inside the editor
-	if ( is_admin() ) {
-		tainacan_blocks_get_category_icon_script();
-		tainacan_blocks_get_common_editor_styles();
-		tainacan_blocks_get_variations_script();
+	protected function __construct() {
+		$this->blocks_dir = __DIR__ . '/blocks';
+		$this->init();
 	}
 
 	/**
-	 * Populates js variables here to avoid calling it for each block
+	 * Initialize the Gutenberg Blocks logic, only if possible.
+	 *
+	 * Via Gutenberg filters, we create the Tainacan category.
+	 * On the theme side, all we need is the common scripts that handle dynamically the imports using conditioner.js.
+	 * On the admin side, we need the blocks registered and their assets (editor-side). The reason why we don't use
+	 * admin_init here is because server side blocks need to be registered within the init.
+	 * Additionally, we also register the Tainacan react components that may be used by block editor scripts and plugin extenders.
 	 */
-	$block_settings = tainacan_blocks_get_plugin_js_settings();
-	$user_settings = \Tainacan\Admin::get_instance()->get_admin_js_user_data();
-	$plugin_settings = \Tainacan\Admin::get_instance()->get_admin_js_localization_params();
+	public function init() {
+		// Via Gutenberg filters, we create the Tainacan category (introduced WP 5.8).
+		if ( class_exists( 'WP_Block_Editor_Context' ) ) {
+			add_filter( 'block_categories_all', [ $this, 'register_categories' ], 10, 2 );
+		} else {
+			add_filter( 'block_categories', [ $this, 'register_categories' ], 10, 2 );
+		}
 
-	// May be needed outside the editor, if server side render is used
-	foreach(TAINACAN_BLOCKS as $block_slug => $block_options) {
-		tainacan_blocks_register_block($block_slug, $block_options, $block_settings, $user_settings, $plugin_settings);
+		// On the theme side, all we need is the common scripts that handle dynamically the imports using conditioner.js.
+		if ( ! is_admin() ) {
+			add_action( 'init', [ $this, 'add_common_theme_scripts' ], 90 );
+			add_action( 'init', [ $this, 'get_common_theme_styles' ], 90 );
+		}
+
+		// On the admin side, we need the blocks registered and their assets (editor-side). Server side blocks need to be registered within init.
+		add_action( 'init', [ $this, 'register_and_enqueue_all_blocks' ], 11 );
+
+		// Additionally, we also register the Tainacan react components that may be used by block editor scripts and plugin extenders.
+		if ( is_admin() ) {
+			add_action( 'init', [ $this, 'register_react_components' ], 12 );
+		}
 	}
-}
 
-/** 
- * Registers a 'generic' Tainacan Block, according to the TAINACAN_BLOCKs array
- * 
- * @param string $block_slug 	The block slug
- * @param array $options {
- *     Optional. Array of arguments.
- *     @type array		 $extra_editor_script_deps		Array of strings containing script dependencies of the editor side script
- *  }
- * @param array $block_settings JSON array containing the block settings from the server
- * @param array $user_settings JSON array containing the user settings from the server
- * @param array $plugin_settings JSON array containing the plugin settings from the server
- */
-function tainacan_blocks_register_block($block_slug, $options = [], $block_settings = [], $user_settings = [], $plugin_settings = []) {
-	global $TAINACAN_BASE_URL;
-	global $TAINACAN_VERSION;
+	/**
+	 * Registers the Tainacan category on the blocks inserter.
+	 *
+	 * @param array $categories
+	 * @param mixed $editor_context
+	 * @return array
+	 */
+	public function register_categories( $categories, $editor_context ) {
+		return array_merge(
+			$categories,
+			[
+				[
+					'slug'  => 'tainacan-blocks',
+					'title' => __( 'Tainacan Blocks', 'tainacan' ),
+				],
+				[
+					'slug'  => 'tainacan-blocks-variations',
+					'title' => __( 'Tainacan Query Loop Variations', 'tainacan' ),
+				],
+			]
+		);
+	}
 
-	// Makes sure translations that use wp.i18n work with our lazy loading strategy (handle matches build: tainacan-chunks-blocks-{slug}-theme)
-	if ( isset($options['set_script_translations']) && $options['set_script_translations'] ) {
+	/**
+	 * Calls the routines responsible for registering the global style, category and both 'generic' and 'special' blocks.
+	 * Only registers blocks that are enabled in settings (or all if none selected).
+	 */
+	public function register_and_enqueue_all_blocks() {
+		// Only needed inside the editor.
+		if ( is_admin() ) {
+			$this->get_category_icon_script();
+			$this->get_common_editor_styles();
+			$this->get_variations_script();
+		}
+
+		/**
+		 * Populates js variables here to avoid calling it for each block.
+		 */
+		$block_settings  = $this->get_plugin_js_settings();
+		$user_settings   = \Tainacan\Admin::get_instance()->get_admin_js_user_data();
+		$plugin_settings = \Tainacan\Admin::get_instance()->get_admin_js_localization_params();
+
+		$enabled = get_option( 'tainacan_option_enabled_blocks', [] );
+		$blocks  = self::$blocks;
+		if ( ! empty( $enabled ) && is_array( $enabled ) ) {
+			$blocks = array_intersect_key( $blocks, array_flip( $enabled ) );
+		}
+
+		// May be needed outside the editor, if server side render is used.
+		foreach ( $blocks as $block_slug => $block_options ) {
+			$this->register_block( $block_slug, $block_options, $block_settings, $user_settings, $plugin_settings );
+		}
+	}
+
+	/**
+	 * Registers a 'generic' Tainacan Block, according to the BLOCKS array.
+	 *
+	 * @param string $block_slug     The block slug.
+	 * @param array  $options        Optional. Array of arguments. @type array $extra_editor_script_deps Array of strings containing script dependencies of the editor side script.
+	 * @param array  $block_settings JSON array containing the block settings from the server.
+	 * @param array  $user_settings  JSON array containing the user settings from the server.
+	 * @param array  $plugin_settings JSON array containing the plugin settings from the server.
+	 */
+	public function register_block( $block_slug, $options = [], $block_settings = [], $user_settings = [], $plugin_settings = [] ) {
+		global $TAINACAN_BASE_URL, $TAINACAN_VERSION;
+
+		// Makes sure translations that use wp.i18n work with our lazy loading strategy (handle matches build: tainacan-chunks-blocks-{slug}-theme).
+		if ( isset( $options['set_script_translations'] ) && $options['set_script_translations'] ) {
+			wp_register_script(
+				'tainacan-chunks-blocks-' . $block_slug . '-theme',
+				$TAINACAN_BASE_URL . '/assets/js/tainacan-chunks-' . $block_slug . '-theme.js',
+				[ 'wp-i18n' ],
+				$TAINACAN_VERSION,
+				true
+			);
+			wp_set_script_translations( 'tainacan-chunks-blocks-' . $block_slug . '-theme', 'tainacan' );
+			wp_add_inline_script( 'wp-i18n', wp_scripts()->print_translations( 'tainacan-chunks-blocks-' . $block_slug . '-theme', false ) );
+		}
+
+		// Creates Register params based on registered scripts and styles.
+		$register_params = [];
+
+		// If there is a server side render callback, we add its render function.
+		if ( isset( $options['render_callback'] ) ) {
+			require_once $this->blocks_dir . '/' . $block_slug . '/save.php';
+			$register_params['render_callback'] = $options['render_callback'];
+			if ( ! isset( $options['keep_inner_blocks'] ) || $options['keep_inner_blocks'] === false ) {
+				$register_params['skip_inner_blocks'] = true;
+			}
+		// Also, none of the rest is necessary regarding blocks that are non server side; their content is independent of editor side scripts and styles.
+		} elseif ( ! is_admin() ) {
+			return;
+		}
+
+		// Defines dependencies for editor script.
+		$editor_script_deps = [ 'wp-blocks', 'wp-i18n', 'wp-element', 'wp-components', 'wp-server-side-render', 'wp-data', 'wp-block-editor' ];
+		if ( isset( $options['extra_editor_script_deps'] ) ) {
+			$editor_script_deps = array_merge( $editor_script_deps, $options['extra_editor_script_deps'] );
+		}
+
+		// Registers Editor Script.
 		wp_register_script(
-			'tainacan-chunks-blocks-' . $block_slug . '-theme',
-			$TAINACAN_BASE_URL . '/assets/js/tainacan-chunks-' . $block_slug . '-theme.js',
-			array('wp-i18n'),
+			$block_slug,
+			$TAINACAN_BASE_URL . '/assets/js/block_' . str_replace( '-', '_', $block_slug ) . '.js',
+			$editor_script_deps,
 			$TAINACAN_VERSION,
 			true
 		);
-		wp_set_script_translations( 'tainacan-chunks-blocks-' . $block_slug . '-theme', 'tainacan' );
-		wp_add_inline_script( 'wp-i18n', wp_scripts()->print_translations('tainacan-chunks-blocks-' . $block_slug . '-theme', false) );
-	}
+		wp_set_script_translations( $block_slug, 'tainacan' );
+		$register_params['editor_script'] = $block_slug;
 
-	// Creates Register params based on registered scripts and styles
-	$register_params = [];
+		// Passes global variables to the blocks editor side.
+		wp_localize_script( $block_slug, 'tainacan_blocks', $block_settings );
+		wp_localize_script( $block_slug, 'tainacan_user', $user_settings );
+		wp_localize_script( $block_slug, 'tainacan_plugin', $plugin_settings );
 
-	// If there is a server side render callback, we add its render function
-	if ( isset($options['render_callback']) ) {
-		require_once( __DIR__ . '/blocks/' . $block_slug . '/save.php' );
+		// Registers style.
+		$style_slug = $block_slug === 'items-gallery' ? 'item-gallery' : $block_slug;
+		wp_register_style(
+			$block_slug,
+			$TAINACAN_BASE_URL . '/assets/css/tainacan-gutenberg-block-' . $style_slug . '.css',
+			[],
+			$TAINACAN_VERSION
+		);
+		$register_params['style'] = $block_slug;
 
-		$register_params['render_callback'] = $options['render_callback'];
-
-		if ( !isset($options['keep_inner_blocks']) || $options['keep_inner_blocks'] === false )
-			$register_params['skip_inner_blocks'] = true;
-
-	// Also, none of the rest is necessary regarding 
-	// blocks that are non server side, their content
-	// is independent of editor side scripts and styles.
-	} else if ( !is_admin() ) {
-		return;
-	}
-
-	// Defines dependencies for editor script
-	$editor_script_deps = array('wp-blocks', 'wp-i18n', 'wp-element', 'wp-components', 'wp-server-side-render', 'wp-data');
-	$editor_script_deps[] = 'wp-block-editor';
-	
-	if ( isset($options['extra_editor_script_deps']) )
-		array_merge($editor_script_deps, $options['extra_editor_script_deps']);
-
-	// Registers Editor Script
-	wp_register_script(
-		$block_slug,
-		$TAINACAN_BASE_URL . '/assets/js/block_' . str_replace('-', '_' , $block_slug) . '.js',
-		$editor_script_deps,
-		$TAINACAN_VERSION,
-		true
-	);
-	wp_set_script_translations( $block_slug, 'tainacan' );
-	$register_params['editor_script'] = $block_slug;
-
-	// Passes global variables to the blocks editor side
-	wp_localize_script( $block_slug, 'tainacan_blocks', $block_settings);
-	wp_localize_script( $block_slug, 'tainacan_user', $user_settings);
-	wp_localize_script( $block_slug, 'tainacan_plugin', $plugin_settings);
-
-	// Registers style
-	wp_register_style(
-		$block_slug,
-		$TAINACAN_BASE_URL . '/assets/css/tainacan-gutenberg-block-' . ( $block_slug === 'items-gallery' ? 'item-gallery' : $block_slug ) . '.css',
-		array(),
-		$TAINACAN_VERSION
-	);
-	$register_params['style'] = $block_slug;
-
-	// Registers the new block
-	if (function_exists('register_block_type')) 
-		register_block_type( __DIR__ . '/blocks/' . $block_slug, $register_params );
-	
-}
-
-/** 
- * Enqueues the global theme styles necessary for the majority of the blocks
- */
-function tainacan_blocks_get_common_theme_styles() {
-	global $TAINACAN_BASE_URL;
-	global $TAINACAN_VERSION;
-
-	wp_enqueue_style(
-		'tainacan-blocks-common-theme-styles',
-		$TAINACAN_BASE_URL . '/assets/css/tainacan-gutenberg-block-common-theme-styles.css',
-		array(),
-		$TAINACAN_VERSION
-	);
-}
-
-/** 
- * Enqueues the global editor styles necessary for the majority of the blocks
- */
-function tainacan_blocks_get_common_editor_styles() {
-	global $TAINACAN_BASE_URL;
-	global $TAINACAN_VERSION;
-
-	wp_enqueue_style(
-		'tainacan-blocks-common-editor-styles',
-		$TAINACAN_BASE_URL . '/assets/css/tainacan-gutenberg-block-common-editor-styles.css',
-		array(),
-		$TAINACAN_VERSION
-	);
-}
-
-/** 
- * Generates the global 'tainacan_blocks' that contains some info from PHP necessary 
- * to the blocks scripts in JS
- */
-function tainacan_blocks_get_plugin_js_settings(){
-	global $TAINACAN_BASE_URL;
-	global $TAINACAN_API_MAX_ITEMS_PER_PAGE;
-	global $wp_version;
-
-	$Tainacan_Collections = \Tainacan\Repositories\Collections::get_instance();
-	$collections = $Tainacan_Collections->fetch( [], 'OBJECT' );
-	$cpts = [];
-	foreach ( $collections as $col ) {
-		$cpts[$col->get_db_identifier()] = $col->get_name();
-	}
-
-	$settings = [
-		'wp_version' => $wp_version,
-		'root'     	 => esc_url_raw( rest_url() ) . 'tainacan/v2',
-		'nonce'   	 => is_user_logged_in() ? wp_create_nonce( 'wp_rest' ) : false,
-		'base_url' 	 => $TAINACAN_BASE_URL,
-		'api_max_items_per_page'    => $TAINACAN_API_MAX_ITEMS_PER_PAGE,
-		'admin_url'  => admin_url('admin.php'),
-		'site_url'	 => site_url(),
-		'theme_items_list_url' => esc_url_raw( get_site_url() ) . '/' . \Tainacan\Theme_Helper::get_instance()->get_items_list_slug(),
-		'collections_post_types' => $cpts,
-		'registered_view_modes' => \Tainacan\Theme_Helper::get_instance()->get_registered_view_modes(),
-		'enabled_view_modes' => \Tainacan\Theme_Helper::get_instance()->get_enabled_view_modes(),
-		'default_view_mode' => \Tainacan\Theme_Helper::get_instance()->get_default_view_mode(),
-		'default_order' => \Tainacan\Theme_Helper::get_instance()->get_default_order(),
-		'default_orderby' => \Tainacan\Theme_Helper::get_instance()->get_default_orderby(),
-		'enable_item_link_query_params' => \Tainacan\Theme_Helper::get_instance()->get_enable_item_link_query_params()
-	];
-	
-	return $settings;
-}
-
-/** 
- * Efectivelly enqueues the common js and passes the necessary global variables
- */
-function tainacan_blocks_add_common_theme_scripts() {
-	global $TAINACAN_BASE_URL;
-	global $TAINACAN_VERSION;
-
-	wp_enqueue_script('underscore');
-
-	wp_enqueue_script(
-		'tainacan-blocks-common-scripts',
-		$TAINACAN_BASE_URL . '/assets/js/tainacan_blocks_common_scripts.js',
-		array('wp-i18n', 'underscore'),
-		$TAINACAN_VERSION,
-		true
-	);
-
-	wp_set_script_translations( 'tainacan-blocks-common-scripts', 'tainacan' );
-
-	$block_settings = tainacan_blocks_get_plugin_js_settings();
-	$user_settings = \Tainacan\Admin::get_instance()->get_admin_js_user_data();
-	$plugin_settings = \Tainacan\Admin::get_instance()->get_admin_js_localization_params();
-
-	wp_localize_script( 'tainacan-blocks-common-scripts', 'tainacan_blocks', $block_settings);
-	wp_localize_script( 'tainacan-blocks-common-scripts', 'tainacan_user', $user_settings);
-	wp_localize_script( 'tainacan-blocks-common-scripts', 'tainacan_plugin', $plugin_settings);
-
-	// Hook into block rendering to detect and immediately enqueue extra assets
-	add_filter('render_block', function($block_content, $block) {
-		if ($block['blockName'] === 'tainacan/faceted-search') {
-			tainacan_blocks_add_extra_faceted_search_assets();
-		} else if ($block['blockName'] === 'tainacan/item-submission-form') {
-			tainacan_blocks_add_extra_item_submission_assets();
+		// Registers the new block.
+		if ( function_exists( 'register_block_type' ) ) {
+			register_block_type( $this->blocks_dir . '/' . $block_slug, $register_params );
 		}
-		return $block_content;
-	}, 10, 2);
-}
+	}
 
-/** 
- * Registers the extra scripts necessary for item submission block
- */
-function tainacan_blocks_add_extra_item_submission_assets() {
-	global $TAINACAN_BASE_URL;
+	/**
+	 * Enqueues the global theme styles necessary for the majority of the blocks.
+	 */
+	public function get_common_theme_styles() {
+		global $TAINACAN_BASE_URL, $TAINACAN_VERSION;
+		wp_enqueue_style(
+			'tainacan-blocks-common-theme-styles',
+			$TAINACAN_BASE_URL . '/assets/css/tainacan-gutenberg-block-common-theme-styles.css',
+			[],
+			$TAINACAN_VERSION
+		);
+	}
 
-	// Registers extra script for Google ReCAPTCHA
-	wp_register_script(
-		'tainacan-google-recaptcha-script',
-		'https://www.google.com/recaptcha/api.js',
-		array(),
-		TAINACAN_VERSION,
-		true 
-	);
-	
-	wp_enqueue_script('tainacan-google-recaptcha-script');	
-	wp_enqueue_style( 'tainacan-fonts', $TAINACAN_BASE_URL . '/assets/fonts/tainacanicons.css', array(), TAINACAN_VERSION );
-		
-	// Registers extra metadata type forms
-	$theme_helper = \Tainacan\Metadata_Types\Metadata_Type_Helper::get_instance();
-	if (isset($theme_helper))
-		$theme_helper->register_metadata_type_component();
-}
+	/**
+	 * Enqueues the global editor styles necessary for the majority of the blocks.
+	 */
+	public function get_common_editor_styles() {
+		global $TAINACAN_BASE_URL, $TAINACAN_VERSION;
+		wp_enqueue_style(
+			'tainacan-blocks-common-editor-styles',
+			$TAINACAN_BASE_URL . '/assets/css/tainacan-gutenberg-block-common-editor-styles.css',
+			[],
+			$TAINACAN_VERSION
+		);
+	}
 
-/** 
- * Registers the extra styles necessary for faceted search block
- */
-function tainacan_blocks_add_extra_faceted_search_assets() {
-	global $TAINACAN_BASE_URL;
-	wp_enqueue_style( 'tainacan-fonts', $TAINACAN_BASE_URL . '/assets/fonts/tainacanicons.css', array(), TAINACAN_VERSION );
-}
+	/**
+	 * Returns the block list (slug => options) for Settings and internal use.
+	 *
+	 * @return array<string, array>
+	 */
+	public function get_blocks() {
 
-/** 
- * Registers the script that inserts the Tainacan icon on the blocks category
- */
-function tainacan_blocks_get_category_icon_script() {
-	global $TAINACAN_BASE_URL;
-	global $TAINACAN_VERSION;
-	
-	wp_enqueue_script(
-		'tainacan-blocks-register-category-icon',
-		$TAINACAN_BASE_URL . '/assets/js/tainacan_blocks_category_icon.js',
-		array('wp-blocks', 'wp-element'),
-		$TAINACAN_VERSION,
-		true
-	);
-}
+		/**
+		 * Filter the block list to allow plugins to completely remove blocks.
+		 *
+		 * @param array<string, array> $blocks The Tainacan available blocks list.
+		 * @return array<string, array> The filtered block list.
+		 */
+		return apply_filters(
+			'tainacan-blocks-available-blocks',
+			self::$blocks
+		);
+	}
 
-/** 
- * Registers the script that inserts the Query Loop Block variations
- */
-function tainacan_blocks_get_variations_script() {
-	global $TAINACAN_BASE_URL;
-	global $TAINACAN_VERSION;
+	/**
+	 * Returns block slug => label for Settings checkboxes. Reads title from each block's block.json.
+	 *
+	 * @return array<string, string>
+	 */
+	public function get_block_labels() {
+		$labels = [];
+		foreach ( array_keys( self::$blocks ) as $slug ) {
+			$path = $this->blocks_dir . '/' . $slug . '/block.json';
+			if ( is_readable( $path ) ) {
+				$json = json_decode( (string) file_get_contents( $path ), true );
+				if ( is_array( $json ) && ! empty( $json['title'] ) ) {
+					$labels[ $slug ] = $json['title'];
+					continue;
+				}
+			}
+			$labels[ $slug ] = $slug;
+		}
+		return $labels;
+	}
 
-	wp_enqueue_script(
-		'tainacan-blocks-query-variations',
-		$TAINACAN_BASE_URL . '/assets/js/tainacan_blocks_query_variations.js',
-		array('wp-blocks', 'wp-components', 'wp-i18n'),
-		$TAINACAN_VERSION,
-		true
-	);
+	/**
+	 * Generates the global 'tainacan_blocks' that contains some info from PHP necessary to the blocks scripts in JS.
+	 * Also includes the variation enable/disable flags for the Query loop variations script.
+	 *
+	 * @return array
+	 */
+	public function get_plugin_js_settings() {
+		global $TAINACAN_BASE_URL, $TAINACAN_API_MAX_ITEMS_PER_PAGE, $wp_version;
 
-	$block_settings = tainacan_blocks_get_plugin_js_settings();
-	wp_localize_script( 'tainacan-blocks-query-variations', 'tainacan_blocks', $block_settings );
-}
+		$Tainacan_Collections = \Tainacan\Repositories\Collections::get_instance();
+		$collections = $Tainacan_Collections->fetch( [], 'OBJECT' );
+		$cpts = [];
+		foreach ( $collections as $col ) {
+			$cpts[ $col->get_db_identifier() ] = $col->get_name();
+		}
 
-/**
- * Registers Tainacan react components that may be used by either block editor
- * scripts or plugin extenders.
- */
-function tainacan_blocks_register_react_components() {
-	global $TAINACAN_BASE_URL;
-	global $TAINACAN_VERSION;
+		$settings = [
+			'wp_version'                  	=> $wp_version,
+			'root'                        	=> esc_url_raw( rest_url() ) . 'tainacan/v2',
+			'nonce'                       	=> is_user_logged_in() ? wp_create_nonce( 'wp_rest' ) : false,
+			'base_url'                    	=> $TAINACAN_BASE_URL,
+			'api_max_items_per_page'      	=> $TAINACAN_API_MAX_ITEMS_PER_PAGE,
+			'admin_url'                   	=> admin_url( 'admin.php' ),
+			'site_url'                    	=> site_url(),
+			'theme_items_list_url'        	=> esc_url_raw( get_site_url() ) . '/' . \Tainacan\Theme_Helper::get_instance()->get_items_list_slug(),
+			'collections_post_types'      	=> $cpts,
+			'registered_view_modes'      	=> \Tainacan\Theme_Helper::get_instance()->get_registered_view_modes(),
+			'enabled_view_modes'          	=> \Tainacan\Theme_Helper::get_instance()->get_enabled_view_modes(),
+			'default_view_mode'           	=> \Tainacan\Theme_Helper::get_instance()->get_default_view_mode(),
+			'default_order'               	=> \Tainacan\Theme_Helper::get_instance()->get_default_order(),
+			'default_orderby'             	=> \Tainacan\Theme_Helper::get_instance()->get_default_orderby(),
+			'enable_item_link_query_params' => \Tainacan\Theme_Helper::get_instance()->get_enable_item_link_query_params(),
+			'enabled_variation_collections' => get_option( 'tainacan_option_enabled_variation_collections', true ),
+			'enabled_variation_taxonomies'  => get_option( 'tainacan_option_enabled_variation_taxonomies', true ),
+			'enabled_variation_items'       => get_option( 'tainacan_option_enabled_variation_items', true ),
+		];
 
-	$dependencies = array( 'wp-element', 'wp-components', 'wp-i18n' );
+		return $settings;
+	}
 
-	wp_register_script(
-        'tainacan-multiple-item-selection-modal',
-        $TAINACAN_BASE_URL . '/assets/js/tainacan_multiple_item_selection_modal.js',
-        $dependencies,
-        $TAINACAN_VERSION,
-        true
-    );
-	wp_register_script(
-        'tainacan-single-item-selection-modal',
-        $TAINACAN_BASE_URL . '/assets/js/tainacan_single_item_selection_modal.js',
-        $dependencies,
-        $TAINACAN_VERSION,
-        true
-    );
-	wp_register_script(
-        'tainacan-single-item-metadatum-selection-modal',
-        $TAINACAN_BASE_URL . '/assets/js/tainacan_single_item_metadatum_selection_modal.js',
-        $dependencies,
-        $TAINACAN_VERSION,
-        true
-    );
-	wp_register_script(
-        'tainacan-single-item-metadata-section-selection-modal',
-        $TAINACAN_BASE_URL . '/assets/js/tainacan_single_item_metadata_section_selection_modal.js',
-        $dependencies,
-        $TAINACAN_VERSION,
-        true
-    );
+	/**
+	 * Effectively enqueues the common js and passes the necessary global variables.
+	 * Hooks into block rendering to detect and immediately enqueue extra assets when needed.
+	 */
+	public function add_common_theme_scripts() {
+		global $TAINACAN_BASE_URL, $TAINACAN_VERSION;
+
+		wp_enqueue_script( 'underscore' );
+		wp_enqueue_script(
+			'tainacan-blocks-common-scripts',
+			$TAINACAN_BASE_URL . '/assets/js/tainacan_blocks_common_scripts.js',
+			[ 'wp-i18n', 'underscore' ],
+			$TAINACAN_VERSION,
+			true
+		);
+		wp_set_script_translations( 'tainacan-blocks-common-scripts', 'tainacan' );
+
+		$block_settings  = $this->get_plugin_js_settings();
+		$user_settings   = \Tainacan\Admin::get_instance()->get_admin_js_user_data();
+		$plugin_settings = \Tainacan\Admin::get_instance()->get_admin_js_localization_params();
+
+		wp_localize_script( 'tainacan-blocks-common-scripts', 'tainacan_blocks', $block_settings );
+		wp_localize_script( 'tainacan-blocks-common-scripts', 'tainacan_user', $user_settings );
+		wp_localize_script( 'tainacan-blocks-common-scripts', 'tainacan_plugin', $plugin_settings );
+
+		// Hook into block rendering to detect and immediately enqueue extra assets.
+		add_filter( 'render_block', function ( $block_content, $block ) {
+			if ( isset( $block['blockName'] ) && $block['blockName'] === 'tainacan/faceted-search' ) {
+				$this->add_extra_faceted_search_assets();
+			} elseif ( isset( $block['blockName'] ) && $block['blockName'] === 'tainacan/item-submission-form' ) {
+				$this->add_extra_item_submission_assets();
+			}
+			return $block_content;
+		}, 10, 2 );
+	}
+
+	/**
+	 * Registers the extra scripts necessary for item submission block.
+	 * Registers extra script for Google ReCAPTCHA and extra metadata type forms.
+	 */
+	public function add_extra_item_submission_assets() {
+		global $TAINACAN_BASE_URL;
+
+		// Registers extra script for Google ReCAPTCHA.
+		wp_register_script(
+			'tainacan-google-recaptcha-script',
+			'https://www.google.com/recaptcha/api.js',
+			[],
+			TAINACAN_VERSION,
+			true
+		);
+		wp_enqueue_script( 'tainacan-google-recaptcha-script' );
+		wp_enqueue_style( 'tainacan-fonts', $TAINACAN_BASE_URL . '/assets/fonts/tainacanicons.css', [], TAINACAN_VERSION );
+
+		// Registers extra metadata type forms.
+		$theme_helper = \Tainacan\Metadata_Types\Metadata_Type_Helper::get_instance();
+		if ( isset( $theme_helper ) ) {
+			$theme_helper->register_metadata_type_component();
+		}
+	}
+
+	/**
+	 * Registers the extra styles necessary for faceted search block.
+	 */
+	public function add_extra_faceted_search_assets() {
+		global $TAINACAN_BASE_URL;
+		wp_enqueue_style( 'tainacan-fonts', $TAINACAN_BASE_URL . '/assets/fonts/tainacanicons.css', [], TAINACAN_VERSION );
+	}
+
+	/**
+	 * Registers the script that inserts the Tainacan icon on the blocks category.
+	 */
+	public function get_category_icon_script() {
+		global $TAINACAN_BASE_URL, $TAINACAN_VERSION;
+		wp_enqueue_script(
+			'tainacan-blocks-register-category-icon',
+			$TAINACAN_BASE_URL . '/assets/js/tainacan_blocks_category_icon.js',
+			[ 'wp-blocks', 'wp-element' ],
+			$TAINACAN_VERSION,
+			true
+		);
+	}
+
+	/**
+	 * Registers the script that inserts the Query Loop Block variations.
+	 * Passes block settings (including variation enable/disable flags) to the script.
+	 */
+	public function get_variations_script() {
+		global $TAINACAN_BASE_URL, $TAINACAN_VERSION;
+
+		wp_enqueue_script(
+			'tainacan-blocks-query-variations',
+			$TAINACAN_BASE_URL . '/assets/js/tainacan_blocks_query_variations.js',
+			[ 'wp-blocks', 'wp-components', 'wp-i18n' ],
+			$TAINACAN_VERSION,
+			true
+		);
+
+		$block_settings = $this->get_plugin_js_settings();
+		wp_localize_script( 'tainacan-blocks-query-variations', 'tainacan_blocks', $block_settings );
+	}
+
+	/**
+	 * Registers Tainacan react components that may be used by either block editor scripts or plugin extenders.
+	 */
+	public function register_react_components() {
+		global $TAINACAN_BASE_URL, $TAINACAN_VERSION;
+		$dependencies = [ 'wp-element', 'wp-components', 'wp-i18n' ];
+
+		wp_register_script(
+			'tainacan-multiple-item-selection-modal',
+			$TAINACAN_BASE_URL . '/assets/js/tainacan_multiple_item_selection_modal.js',
+			$dependencies,
+			$TAINACAN_VERSION,
+			true
+		);
+		wp_register_script(
+			'tainacan-single-item-selection-modal',
+			$TAINACAN_BASE_URL . '/assets/js/tainacan_single_item_selection_modal.js',
+			$dependencies,
+			$TAINACAN_VERSION,
+			true
+		);
+		wp_register_script(
+			'tainacan-single-item-metadatum-selection-modal',
+			$TAINACAN_BASE_URL . '/assets/js/tainacan_single_item_metadatum_selection_modal.js',
+			$dependencies,
+			$TAINACAN_VERSION,
+			true
+		);
+		wp_register_script(
+			'tainacan-single-item-metadata-section-selection-modal',
+			$TAINACAN_BASE_URL . '/assets/js/tainacan_single_item_metadata_section_selection_modal.js',
+			$dependencies,
+			$TAINACAN_VERSION,
+			true
+		);
+	}
 }

--- a/src/views/gutenberg-blocks/class-tainacan-gutenberg-blocks.php
+++ b/src/views/gutenberg-blocks/class-tainacan-gutenberg-blocks.php
@@ -8,7 +8,7 @@ defined( 'ABSPATH' ) or die( 'No script kiddies please!' );
  * Handles registration of Tainacan Gutenberg blocks and Query loop variations.
  * Not a page; provides block list and labels for Settings and filters registration by options.
  */
-class Gutenberg_Block {
+class Gutenberg_Blocks {
 	use \Tainacan\Traits\Singleton_Instance;
 
 	/**

--- a/src/views/gutenberg-blocks/js/tainacan-blocks-query-variations.js
+++ b/src/views/gutenberg-blocks/js/tainacan-blocks-query-variations.js
@@ -8,69 +8,24 @@ const { __ } = wp.i18n;
 /**
  * Adds Tainacan Collections as a query loop variation
  */
-registerBlockVariation( 'core/query', {
-    name: 'tainacan-collection',
-    title: __( 'Tainacan collections', 'tainacan'),
-    icon: collectionsIcon,
-    category: 'tainacan-blocks-variations',
-    description: __('Displays a list of Tainacan collections', 'tainacan'),
-    isActive: ( { namespace, query } ) => {
-            return (
-                namespace === 'tainacan-collection'
-                && query.postType === 'tainacan-collection'
-            );
-    },
-    attributes: {
-        namespace: 'tainacan-collection',
-        query: {
-            postType: 'tainacan-collection',
-            perPage: 12,
-            offset: 0
-        },
-        align: 'wide',
-        displayLayout: {
-            type: 'flex',
-            columns: 4
-        }
-    },
-    allowedControls: [ 'inherit', 'order', 'taxQuery', 'search' ],
-    innerBlocks: [
-        [
-            'core/post-template',
-            {},
-            [
-                [ 'core/post-featured-image' ],
-                [ 'core/post-title' ]
-            ],
-        ]
-    ]
-} );
-
-/**
- * Loops on Tainacan Collections post types to create items list variations
- */
-const POST_TYPES = tainacan_blocks.collections_post_types;
-
-Object.keys(POST_TYPES).forEach((postType) => {
-    const postName = POST_TYPES[postType];
-    const VARIATION_NAME = 'tainacan-items-' + postType;
-
+// Unchecked checkboxes are stored as empty string; only register when explicitly enabled (true or not set).
+if ( tainacan_blocks.enabled_variation_collections !== false && tainacan_blocks.enabled_variation_collections !== '' ) {
     registerBlockVariation( 'core/query', {
-        name: VARIATION_NAME,
-        title: postName,
-        icon: itemsIcon,
+        name: 'tainacan-collection',
+        title: __( 'Tainacan collections', 'tainacan'),
+        icon: collectionsIcon,
         category: 'tainacan-blocks-variations',
-        description: __('Displays a list of Tainacan items from a collection', 'tainacan'),
+        description: __('Displays a list of Tainacan collections', 'tainacan'),
         isActive: ( { namespace, query } ) => {
                 return (
-                    namespace === VARIATION_NAME
-                    && query.postType === postType
+                    namespace === 'tainacan-collection'
+                    && query.postType === 'tainacan-collection'
                 );
         },
         attributes: {
-            namespace: VARIATION_NAME,
+            namespace: 'tainacan-collection',
             query: {
-                postType: postType,
+                postType: 'tainacan-collection',
                 perPage: 12,
                 offset: 0
             },
@@ -92,47 +47,100 @@ Object.keys(POST_TYPES).forEach((postType) => {
             ]
         ]
     } );
-});
+}
 
+/**
+ * Loops on Tainacan Collections post types to create items list variations
+ */
+// Unchecked checkboxes are stored as empty string; only register when explicitly enabled (true or not set).
+if ( tainacan_blocks.enabled_variation_items !== false && tainacan_blocks.enabled_variation_items !== '' ) {
+    const POST_TYPES = tainacan_blocks.collections_post_types;
+
+    Object.keys(POST_TYPES).forEach((postType) => {
+        const postName = POST_TYPES[postType];
+        const VARIATION_NAME = 'tainacan-items-' + postType;
+
+        registerBlockVariation( 'core/query', {
+            name: VARIATION_NAME,
+            title: postName,
+            icon: itemsIcon,
+            category: 'tainacan-blocks-variations',
+            description: __('Displays a list of Tainacan items from a collection', 'tainacan'),
+            isActive: ( { namespace, query } ) => {
+                    return (
+                        namespace === VARIATION_NAME
+                        && query.postType === postType
+                    );
+            },
+            attributes: {
+                namespace: VARIATION_NAME,
+                query: {
+                    postType: postType,
+                    perPage: 12,
+                    offset: 0
+                },
+                align: 'wide',
+                displayLayout: {
+                    type: 'flex',
+                    columns: 4
+                }
+            },
+            allowedControls: [ 'inherit', 'order', 'taxQuery', 'search' ],
+            innerBlocks: [
+                [
+                    'core/post-template',
+                    {},
+                    [
+                        [ 'core/post-featured-image' ],
+                        [ 'core/post-title' ]
+                    ],
+                ]
+            ]
+        } );
+    });
+}
 
 /**
  * Adds Tainacan Taxonomies as a query loop variation
  */
-registerBlockVariation( 'core/query', {
-    name: 'tainacan-taxonomies',
-    title: __( 'Tainacan taxonomies', 'tainacan'),
-    icon: taxonomiesIcon,
-    category: 'tainacan-blocks-variations',
-    description: __('Displays a list of Tainacan taxonomies', 'tainacan'),
-    isActive: ( { namespace, query } ) => {
-            return (
-                namespace === 'tainacan-taxonomy'
-                && query.postType === 'tainacan-taxonomy'
-            );
-    },
-    attributes: {
-        namespace: 'tainacan-taxonomy',
-        query: {
-            postType: 'tainacan-taxonomy',
-            perPage: 12,
-            offset: 0
+// Unchecked checkboxes are stored as empty string; only register when explicitly enabled (true or not set).
+if ( tainacan_blocks.enabled_variation_taxonomies !== false && tainacan_blocks.enabled_variation_taxonomies !== '' ) {
+    registerBlockVariation( 'core/query', {
+        name: 'tainacan-taxonomies',
+        title: __( 'Tainacan taxonomies', 'tainacan'),
+        icon: taxonomiesIcon,
+        category: 'tainacan-blocks-variations',
+        description: __('Displays a list of Tainacan taxonomies', 'tainacan'),
+        isActive: ( { namespace, query } ) => {
+                return (
+                    namespace === 'tainacan-taxonomy'
+                    && query.postType === 'tainacan-taxonomy'
+                );
         },
-        align: 'wide',
-        displayLayout: {
-            type: 'flex',
-            columns: 4
-        }
-    },
-    allowedControls: [ 'inherit', 'order', 'search' ],
-    innerBlocks: [
-        [
-            'core/post-template',
-            {},
+        attributes: {
+            namespace: 'tainacan-taxonomy',
+            query: {
+                postType: 'tainacan-taxonomy',
+                perPage: 12,
+                offset: 0
+            },
+            align: 'wide',
+            displayLayout: {
+                type: 'flex',
+                columns: 4
+            }
+        },
+        allowedControls: [ 'inherit', 'order', 'search' ],
+        innerBlocks: [
             [
-                // [ 'core/post-featured-image' ],
-                [ 'core/post-title' ]
-            ],
+                'core/post-template',
+                {},
+                [
+                    // [ 'core/post-featured-image' ],
+                    [ 'core/post-title' ]
+                ],
+            ]
         ]
-    ]
-} );
+    } );
+}
 

--- a/src/views/settings/class-tainacan-settings.php
+++ b/src/views/settings/class-tainacan-settings.php
@@ -328,23 +328,23 @@ class Settings extends Pages {
 			'tainacan_settings'
 		);
 
-		$gutenberg_block = \Tainacan\Gutenberg_Block::get_instance();
+		$gutenberg_blocks = \Tainacan\Gutenberg_Blocks::get_instance();
 		$this->create_tainacan_setting( array(
 			'id' => 'enabled_blocks',
 			'section' => 'tainacan_settings_gutenberg_blocks',
-			'title' => __( 'Enabled blocks', 'tainacan' ),
-			'label' => $gutenberg_block->get_block_labels(),
+			'title' => __( 'Enabled Tainacan blocks', 'tainacan' ),
+			'label' => $gutenberg_blocks->get_block_labels(),
 			'type' => 'array',
 			'input_type' => 'checkbox',
-			'default' => array_keys( $gutenberg_block->get_blocks() ),
+			'default' => array_keys( $gutenberg_blocks->get_blocks() ),
 			'sanitize_callback' => array( $this, 'sanitize_enabled_blocks' ),
 		) );
 
 		$this->create_tainacan_setting( array(
 			'id' => 'enabled_variation_items',
 			'section' => 'tainacan_settings_gutenberg_blocks',
-			'title' => __( 'Tainacan collection items', 'tainacan' ),
-			'label' => __( 'Show the Query loop variations for Tainacan collection items', 'tainacan' ),
+			'title' => __( 'Query loop variations for collection items', 'tainacan' ),
+			'label' => __( 'Show the Query loop block variations for each Tainacan collection items', 'tainacan' ),
 			'description' => __( 'These variations will display a list of Tainacan items from each collection using the WordPress Core Query loop.', 'tainacan' ),
 			'type' => 'boolean',
 			'input_type' => 'checkbox',
@@ -355,8 +355,8 @@ class Settings extends Pages {
 		$this->create_tainacan_setting( array(
 			'id' => 'enabled_variation_collections',
 			'section' => 'tainacan_settings_gutenberg_blocks',
-			'title' => __( 'Tainacan collections', 'tainacan' ),
-			'label' => __( 'Show the Query loop variation for Tainacan collections', 'tainacan' ),
+			'title' => __( 'Query loop variation for collections', 'tainacan' ),
+			'label' => __( 'Show the Query loop block variation for Tainacan collections', 'tainacan' ),
 			'description' => __( 'This variation will display a list of Tainacan collections using the WordPress Core Query loop.', 'tainacan' ),
 			'type' => 'boolean',
 			'input_type' => 'checkbox',
@@ -367,8 +367,8 @@ class Settings extends Pages {
 		$this->create_tainacan_setting( array(
 			'id' => 'enabled_variation_taxonomies',
 			'section' => 'tainacan_settings_gutenberg_blocks',
-			'title' => __( 'Tainacan taxonomies', 'tainacan' ),
-			'label' => __( 'Show the Query loop variation for Tainacan taxonomies', 'tainacan' ),
+			'title' => __( 'Query loop variation for taxonomies', 'tainacan' ),
+			'label' => __( 'Show the Query loop block variation for Tainacan taxonomies', 'tainacan' ),
 			'description' => __( 'This variation will display a list of Tainacan taxonomies using the WordPress Core Query loop.', 'tainacan' ),
 			'type' => 'boolean',
 			'input_type' => 'checkbox',
@@ -630,7 +630,7 @@ class Settings extends Pages {
 	 * @return array
 	 */
 	public function sanitize_enabled_blocks( $input ) {
-		$allowed = array_keys( \Tainacan\Gutenberg_Block::get_instance()->get_blocks() );
+		$allowed = array_keys( \Tainacan\Gutenberg_Blocks::get_instance()->get_blocks() );
 		if ( ! is_array( $input ) ) {
 			return [];
 		}

--- a/src/views/settings/class-tainacan-settings.php
+++ b/src/views/settings/class-tainacan-settings.php
@@ -319,6 +319,64 @@ class Settings extends Pages {
 		) );
 
 		/**
+		 * Gutenberg blocks -----------------------------------------------------
+		 */
+		add_settings_section(
+			'tainacan_settings_gutenberg_blocks',
+			__( 'Gutenberg blocks', 'tainacan' ),
+			array( $this, 'gutenberg_blocks_section_description' ),
+			'tainacan_settings'
+		);
+
+		$gutenberg_block = \Tainacan\Gutenberg_Block::get_instance();
+		$this->create_tainacan_setting( array(
+			'id' => 'enabled_blocks',
+			'section' => 'tainacan_settings_gutenberg_blocks',
+			'title' => __( 'Enabled blocks', 'tainacan' ),
+			'label' => $gutenberg_block->get_block_labels(),
+			'type' => 'array',
+			'input_type' => 'checkbox',
+			'default' => array_keys( $gutenberg_block->get_blocks() ),
+			'sanitize_callback' => array( $this, 'sanitize_enabled_blocks' ),
+		) );
+
+		$this->create_tainacan_setting( array(
+			'id' => 'enabled_variation_items',
+			'section' => 'tainacan_settings_gutenberg_blocks',
+			'title' => __( 'Tainacan collection items', 'tainacan' ),
+			'label' => __( 'Show the Query loop variations for Tainacan collection items', 'tainacan' ),
+			'description' => __( 'These variations will display a list of Tainacan items from each collection using the WordPress Core Query loop.', 'tainacan' ),
+			'type' => 'boolean',
+			'input_type' => 'checkbox',
+			'sanitize_callback' => 'rest_sanitize_boolean',
+			'default' => true,
+		) );
+
+		$this->create_tainacan_setting( array(
+			'id' => 'enabled_variation_collections',
+			'section' => 'tainacan_settings_gutenberg_blocks',
+			'title' => __( 'Tainacan collections', 'tainacan' ),
+			'label' => __( 'Show the Query loop variation for Tainacan collections', 'tainacan' ),
+			'description' => __( 'This variation will display a list of Tainacan collections using the WordPress Core Query loop.', 'tainacan' ),
+			'type' => 'boolean',
+			'input_type' => 'checkbox',
+			'sanitize_callback' => 'rest_sanitize_boolean',
+			'default' => true,
+		) );
+
+		$this->create_tainacan_setting( array(
+			'id' => 'enabled_variation_taxonomies',
+			'section' => 'tainacan_settings_gutenberg_blocks',
+			'title' => __( 'Tainacan taxonomies', 'tainacan' ),
+			'label' => __( 'Show the Query loop variation for Tainacan taxonomies', 'tainacan' ),
+			'description' => __( 'This variation will display a list of Tainacan taxonomies using the WordPress Core Query loop.', 'tainacan' ),
+			'type' => 'boolean',
+			'input_type' => 'checkbox',
+			'sanitize_callback' => 'rest_sanitize_boolean',
+			'default' => true,
+		) );
+
+		/**
 		 * Google reCAPTCHA -----------------------------------------------------
 		 */
 		add_settings_section(
@@ -555,6 +613,28 @@ class Settings extends Pages {
 			<?php esc_html_e('Options that will be used as default for items list in the collection and repository pages. They might be overridden by collection settings or theme options.', 'tainacan');?>
 		</p>
 	<?php
+	}
+
+	public function gutenberg_blocks_section_description() {
+	?>
+		<p class="settings-section-description">
+			<?php esc_html_e( 'Disabling blocks or Query loop variations can make the block editor lighter and reduce the number of options in the inserter.', 'tainacan' ); ?>
+		</p>
+	<?php
+	}
+
+	/**
+	 * Sanitizes the enabled_blocks setting: ensures value is an array of strings and only allows known block slugs.
+	 *
+	 * @param mixed $input
+	 * @return array
+	 */
+	public function sanitize_enabled_blocks( $input ) {
+		$allowed = array_keys( \Tainacan\Gutenberg_Block::get_instance()->get_blocks() );
+		if ( ! is_array( $input ) ) {
+			return [];
+		}
+		return array_values( array_intersect( array_map( 'sanitize_text_field', $input ), $allowed ) );
 	}
 
 	public function print_section_info() {

--- a/src/views/settings/tainacan-settings.scss
+++ b/src/views/settings/tainacan-settings.scss
@@ -15,7 +15,16 @@
     td .description {
         font-size: 0.875em;
     }
+    // Only apply column layout if there are more than 8 children
+    .multiple-options:has(label:nth-child(9)) {
+        display: grid;
+        grid-template-columns: repeat(auto-fill, 320px);
+        gap: .5em var(--tainacan-one-column);
 
+        br {
+            display: none;
+        }
+    }
     .form-footer {
         position: sticky;
         bottom: 0;


### PR DESCRIPTION
We decided to use a new section in the Settings screen instead of creating a dedicated page, since it followed a pattern too similar to the settings one. It also keeps most plugin definitions in one place.

Closes #879 

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Introduces new settings that conditionally prevent block/variation registration, which can change editor behavior and available blocks depending on stored options. Refactors block bootstrapping into a new class, so hook timing/initialization regressions are possible.
> 
> **Overview**
> Adds a new **Settings → Gutenberg blocks** section that lets admins choose which Tainacan blocks are enabled and toggle the three Query Loop variation groups (collections, per-collection items, taxonomies), including sanitization for the enabled-blocks list.
> 
> Refactors Gutenberg block bootstrapping from the old procedural `class-tainacan-gutenberg-block.php` into a new singleton `Gutenberg_Blocks` class, and uses the saved options to filter which blocks/variation scripts get registered/enqueued. The variations JS now conditionally registers each variation based on the new flags.
> 
> Updates Settings page styling so large checkbox lists (`.multiple-options`) switch to a grid layout when there are many options.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f3a71e1613ef7fbe0c6a31eabb908ae856146fc8. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->