### PR TITLE
Adds `html_formatting` option to display multivalued metadata as HTML list #868

### DIFF
--- a/src/classes/entities/class-tainacan-item-metadata-entity.php
+++ b/src/classes/entities/class-tainacan-item-metadata-entity.php
@@ -160,14 +160,14 @@ class Item_Metadata_Entity extends Entity {
 		$return = '';
 		
 		if ( $this->is_multiple() ) {
-			$value_markup = $metadatum->get_value_markup();
-			if ( $value_markup === 'list' ) {
+			$html_formatting = $metadatum->get_html_formatting();
+			if ( $html_formatting === 'list' ) {
 				if ( count( $value ) === 1 ) {
-					$return .= esc_html( (string) reset( $value ) );
+					$return .= ( (string) reset( $value ) );
 				} else {
 					$return .= '<ul>';
 					foreach ( $value as $v ) {
-						$return .= '<li>' . esc_html( (string) $v ) . '</li>';
+						$return .= '<li>' . ( (string) $v ) . '</li>';
 					}
 					$return .= '</ul>';
 				}

--- a/src/classes/entities/class-tainacan-item-metadata-entity.php
+++ b/src/classes/entities/class-tainacan-item-metadata-entity.php
@@ -160,21 +160,33 @@ class Item_Metadata_Entity extends Entity {
 		$return = '';
 		
 		if ( $this->is_multiple() ) {
-			$total = sizeof($value);
-			$count = 0;
-			$prefix = $this->get_multivalue_prefix();
-			$suffix = $this->get_multivalue_suffix();
-			$separator = $this->get_multivalue_separator();
-			
-			foreach ($value as $v) {
-				$return .= $prefix;
-				$return .= (string) $v;
-				$return .= $suffix;
-				$count ++;
-				if ($count < $total)
-					$return .= $separator;
+			$value_markup = $metadatum->get_value_markup();
+			if ( $value_markup === 'list' ) {
+				if ( count( $value ) === 1 ) {
+					$return .= esc_html( (string) reset( $value ) );
+				} else {
+					$return .= '<ul>';
+					foreach ( $value as $v ) {
+						$return .= '<li>' . esc_html( (string) $v ) . '</li>';
+					}
+					$return .= '</ul>';
+				}
+			} else {
+				$total = sizeof($value);
+				$count = 0;
+				$prefix = $this->get_multivalue_prefix();
+				$suffix = $this->get_multivalue_suffix();
+				$separator = $this->get_multivalue_separator();
+				foreach ( $value as $v ) {
+					$return .= $prefix;
+					$return .= (string) $v;
+					$return .= $suffix;
+					$count++;
+					if ( $count < $total ) {
+						$return .= $separator;
+					}
+				}
 			}
-
 		} else {
 			$return = (string) $value;
 		}

--- a/src/classes/entities/class-tainacan-item-metadata-entity.php
+++ b/src/classes/entities/class-tainacan-item-metadata-entity.php
@@ -162,9 +162,10 @@ class Item_Metadata_Entity extends Entity {
 		if ( $this->is_multiple() ) {
 			$html_formatting = $metadatum->get_html_formatting();
 			if ( $html_formatting === 'list' ) {
-				if ( count( $value ) === 1 ) {
+				$total = count( $value );
+				if ( $total === 1 ) {
 					$return .= ( (string) reset( $value ) );
-				} else {
+				} elseif ( $total > 1 ) {
 					$return .= '<ul>';
 					foreach ( $value as $v ) {
 						$return .= '<li>' . ( (string) $v ) . '</li>';

--- a/src/classes/entities/class-tainacan-metadatum.php
+++ b/src/classes/entities/class-tainacan-metadatum.php
@@ -24,7 +24,7 @@ class Metadatum extends Entity {
 		$required,
 		$multiple,
 		$display,
-		$value_markup,
+		$html_formatting,
 		$allow_advanced_search,
 		$cardinality,
 		$collection_key,
@@ -76,18 +76,17 @@ class Metadatum extends Entity {
 	}
 
 	/**
-	 * @param string $value_markup
+	 * @param string $html_formatting
 	 */
-	function set_value_markup( $value_markup ) {
-		$this->set_mapped_property('value_markup', $value_markup);
+	function set_html_formatting( $html_formatting ) {
+		$this->set_mapped_property('html_formatting', $html_formatting);
 	}
 
 	/**
 	 * @return string 'inline' or 'list'. Defaults to 'inline' when not set.
 	 */
-	function get_value_markup() {
-		$value = $this->get_mapped_property('value_markup');
-		return ( $value === '' || $value === null ) ? 'inline' : $value;
+	function get_html_formatting() {
+		return ( $this->get_metadata_type() == 'Tainacan\Metadata_Types\Compound' && $this->is_multiple() ) ? 'list' : $this->get_mapped_property('html_formatting');
 	}
 
 	/**

--- a/src/classes/entities/class-tainacan-metadatum.php
+++ b/src/classes/entities/class-tainacan-metadatum.php
@@ -24,6 +24,7 @@ class Metadatum extends Entity {
 		$required,
 		$multiple,
 		$display,
+		$value_markup,
 		$allow_advanced_search,
 		$cardinality,
 		$collection_key,
@@ -72,6 +73,21 @@ class Metadatum extends Entity {
 	 */
 	function get_display(){
 		return $this->get_mapped_property('display');
+	}
+
+	/**
+	 * @param string $value_markup
+	 */
+	function set_value_markup( $value_markup ) {
+		$this->set_mapped_property('value_markup', $value_markup);
+	}
+
+	/**
+	 * @return string 'inline' or 'list'. Defaults to 'inline' when not set.
+	 */
+	function get_value_markup() {
+		$value = $this->get_mapped_property('value_markup');
+		return ( $value === '' || $value === null ) ? 'inline' : $value;
 	}
 
 	/**

--- a/src/classes/repositories/class-tainacan-metadata.php
+++ b/src/classes/repositories/class-tainacan-metadata.php
@@ -199,6 +199,15 @@ class Metadata extends Repository {
 				'description' => __( 'Display by default on listing or do not display or never display.', 'tainacan' ),
 				'default'     => 'no'
 			],
+			'value_markup'          => [
+				'map'         => 'meta',
+				'title'       => __( 'Value markup', 'tainacan' ),
+				'type'        => 'string',
+				'validation'  => v::stringType()->in( [ 'inline', 'list' ] ),
+				'enum'        => [ 'inline', 'list' ],
+				'description' => __( 'How to display multiple values: inline with separators or as a list. Only applies when the metadatum allows multiple values.', 'tainacan' ),
+				'default'     => 'inline'
+			],
 			'allow_advanced_search' => [
 				'map'         => 'meta',
 				'title'       => __( 'Allow advanced search', 'tainacan' ),

--- a/src/classes/repositories/class-tainacan-metadata.php
+++ b/src/classes/repositories/class-tainacan-metadata.php
@@ -201,7 +201,7 @@ class Metadata extends Repository {
 			],
 			'html_formatting'          => [
 				'map'         => 'meta',
-				'title'       => __( 'Value markup', 'tainacan' ),
+				'title'       => __( 'HTML formatting', 'tainacan' ),
 				'type'        => 'string',
 				'validation'  => v::stringType()->in( [ 'inline', 'list' ] ),
 				'enum'        => [ 'inline', 'list' ],

--- a/src/classes/repositories/class-tainacan-metadata.php
+++ b/src/classes/repositories/class-tainacan-metadata.php
@@ -199,7 +199,7 @@ class Metadata extends Repository {
 				'description' => __( 'Display by default on listing or do not display or never display.', 'tainacan' ),
 				'default'     => 'no'
 			],
-			'value_markup'          => [
+			'html_formatting'          => [
 				'map'         => 'meta',
 				'title'       => __( 'Value markup', 'tainacan' ),
 				'type'        => 'string',

--- a/src/views/admin/components/edition/metadatum-edition-form.vue
+++ b/src/views/admin/components/edition/metadatum-edition-form.vue
@@ -263,7 +263,7 @@
                                 <b-field
                                         v-if="!originalMetadatum.metadata_type_object.core && form.parent == 0 && form.multiple == 'yes'"
                                         :addons="false"
-                                        style="margin: 0 0 1em 1.5em;">
+                                        style="margin: 0 0 0 1.5em;">
                                     <div 
                                             style="margin-top: 0;"
                                             class="metadata-form-section"
@@ -296,6 +296,56 @@
                                                 :placeholder="$i18n.get('instruction_2_or_more')"
                                                 :model-value="form.cardinality ? Number(form.cardinality) : null"
                                                 @update:model-value="(newCardinalty) => form.cardinality = newCardinalty ? Number(newCardinalty) : ''" />
+                                    </transition>
+                                </b-field>
+                            </transition>
+
+                            <transition name="filter-item">
+                                <b-field
+                                        v-if="!originalMetadatum.metadata_type_object.core && form.parent == 0 && form.multiple == 'yes'"
+                                        :type="formErrors['value_markup'] != undefined ? 'is-danger' : ''"
+                                        :message="formErrors['value_markup'] != undefined ? formErrors['value_markup'] : ''"
+                                        :addons="false"
+                                        style="margin: 0 0 1em 1.5em;">
+                                    <div 
+                                            style="margin-top: 0;"
+                                            class="metadata-form-section"
+                                            @click="showValueMarkupOptions = !showValueMarkupOptions;">
+                                        <span 
+                                                aria-hidden="true"
+                                                class="icon">
+                                            <i 
+                                                    class="tainacan-icon"
+                                                    :class="showValueMarkupOptions ? 'tainacan-icon-arrowdown' : 'tainacan-icon-arrowright tainacan-icon-is-rtl-mirrored'" />
+                                        </span>
+                                        <strong>
+                                            {{ $i18n.getHelperTitle('metadata', 'value_markup') }}
+                                            <help-button
+                                                    :title="$i18n.getHelperTitle('metadata', 'value_markup')"
+                                                    :message="$i18n.getHelperMessage('metadata', 'value_markup')"
+                                                    :extra-classes="isRepositoryLevel ? 'tainacan-repository-tooltip' : ''" />
+                                        </strong>
+                                        <hr>
+                                    </div>
+                                    <transition name="filter-item">
+                                        <div 
+                                                v-if="showValueMarkupOptions && form.multiple == 'yes'"
+                                                style="display: inline-flex; gap: 1em;">
+                                            <b-radio
+                                                    v-model="form.value_markup"
+                                                    name="value_markup"
+                                                    native-value="inline"
+                                                    @update:model-value="clearErrors('value_markup')">
+                                                {{ $i18n.get('label_value_markup_inline') }}
+                                            </b-radio>
+                                            <b-radio
+                                                    v-model="form.value_markup"
+                                                    name="value_markup"
+                                                    native-value="list"
+                                                    @update:model-value="clearErrors('value_markup')">
+                                                {{ $i18n.get('label_value_markup_list') }}
+                                            </b-radio>
+                                        </div>
                                     </transition>
                                 </b-field>
                             </transition>
@@ -514,7 +564,8 @@
                 isUpdating: false,
                 hideMetadataTypeOptions: false,
                 showAdvancedOptions: false,
-                showCardinalityOptions: false
+                showCardinalityOptions: false,
+                showValueMarkupOptions: false
             }
         },
         watch: {
@@ -530,6 +581,12 @@
 
             if (this.form.cardinality && Number(this.form.cardinality) > 1)
                 this.showCardinalityOptions = true;
+
+            if (this.form.value_markup === 'list')
+                this.showValueMarkupOptions = true;
+
+            if (!this.form.value_markup)
+                this.form.value_markup = 'inline';
 
             this.formErrors = this.form.formErrors != undefined ? this.form.formErrors : {};
             this.formErrorMessage = this.form.formErrors != undefined ? this.form.formErrorMessage : '';

--- a/src/views/admin/components/edition/metadatum-edition-form.vue
+++ b/src/views/admin/components/edition/metadatum-edition-form.vue
@@ -302,48 +302,51 @@
 
                             <transition name="filter-item">
                                 <b-field
-                                        v-if="!originalMetadatum.metadata_type_object.core && form.parent == 0 && form.multiple == 'yes'"
-                                        :type="formErrors['value_markup'] != undefined ? 'is-danger' : ''"
-                                        :message="formErrors['value_markup'] != undefined ? formErrors['value_markup'] : ''"
+                                        v-if="!originalMetadatum.metadata_type_object.core && 
+                                            originalMetadatum.metadata_type_object.component != 'tainacan-compound' &&
+                                            form.parent == 0 &&
+                                            form.multiple == 'yes'"
+                                        :type="formErrors['html_formatting'] != undefined ? 'is-danger' : ''"
+                                        :message="formErrors['html_formatting'] != undefined ? formErrors['html_formatting'] : ''"
                                         :addons="false"
                                         style="margin: 0 0 1em 1.5em;">
                                     <div 
                                             style="margin-top: 0;"
                                             class="metadata-form-section"
-                                            @click="showValueMarkupOptions = !showValueMarkupOptions;">
+                                            @click="showHTMLFormattingOptions = !showHTMLFormattingOptions;">
                                         <span 
                                                 aria-hidden="true"
                                                 class="icon">
                                             <i 
                                                     class="tainacan-icon"
-                                                    :class="showValueMarkupOptions ? 'tainacan-icon-arrowdown' : 'tainacan-icon-arrowright tainacan-icon-is-rtl-mirrored'" />
+                                                    :class="showHTMLFormattingOptions ? 'tainacan-icon-arrowdown' : 'tainacan-icon-arrowright tainacan-icon-is-rtl-mirrored'" />
                                         </span>
                                         <strong>
-                                            {{ $i18n.getHelperTitle('metadata', 'value_markup') }}
+                                            {{ $i18n.getHelperTitle('metadata', 'html_formatting') }}
                                             <help-button
-                                                    :title="$i18n.getHelperTitle('metadata', 'value_markup')"
-                                                    :message="$i18n.getHelperMessage('metadata', 'value_markup')"
+                                                    :title="$i18n.getHelperTitle('metadata', 'html_formatting')"
+                                                    :message="$i18n.getHelperMessage('metadata', 'html_formatting')"
                                                     :extra-classes="isRepositoryLevel ? 'tainacan-repository-tooltip' : ''" />
                                         </strong>
                                         <hr>
                                     </div>
                                     <transition name="filter-item">
                                         <div 
-                                                v-if="showValueMarkupOptions && form.multiple == 'yes'"
+                                                v-if="showHTMLFormattingOptions && form.multiple == 'yes'"
                                                 style="display: inline-flex; gap: 1em;">
                                             <b-radio
-                                                    v-model="form.value_markup"
-                                                    name="value_markup"
+                                                    v-model="form.html_formatting"
+                                                    name="html_formatting"
                                                     native-value="inline"
-                                                    @update:model-value="clearErrors('value_markup')">
-                                                {{ $i18n.get('label_value_markup_inline') }}
+                                                    @update:model-value="clearErrors('html_formatting')">
+                                                {{ $i18n.get('label_html_formatting_inline') }}
                                             </b-radio>
                                             <b-radio
-                                                    v-model="form.value_markup"
-                                                    name="value_markup"
+                                                    v-model="form.html_formatting"
+                                                    name="html_formatting"
                                                     native-value="list"
-                                                    @update:model-value="clearErrors('value_markup')">
-                                                {{ $i18n.get('label_value_markup_list') }}
+                                                    @update:model-value="clearErrors('html_formatting')">
+                                                {{ $i18n.get('label_html_formatting_list') }}
                                             </b-radio>
                                         </div>
                                     </transition>
@@ -565,7 +568,7 @@
                 hideMetadataTypeOptions: false,
                 showAdvancedOptions: false,
                 showCardinalityOptions: false,
-                showValueMarkupOptions: false
+                showHTMLFormattingOptions: false
             }
         },
         watch: {
@@ -582,11 +585,11 @@
             if (this.form.cardinality && Number(this.form.cardinality) > 1)
                 this.showCardinalityOptions = true;
 
-            if (this.form.value_markup === 'list')
-                this.showValueMarkupOptions = true;
+            if (this.form.html_formatting === 'list')
+                this.showHTMLFormattingOptions = true;
 
-            if (!this.form.value_markup)
-                this.form.value_markup = 'inline';
+            if (!this.form.html_formatting)
+                this.form.html_formatting = 'inline';
 
             this.formErrors = this.form.formErrors != undefined ? this.form.formErrors : {};
             this.formErrorMessage = this.form.formErrors != undefined ? this.form.formErrorMessage : '';

--- a/src/views/admin/components/lists/items-list.vue
+++ b/src/views/admin/components/lists/items-list.vue
@@ -998,7 +998,7 @@
 
                         <!-- Remaining metadata -->
                         <div
-                                class="media"
+                                class="media content"
                                 @click.left="onClickItem($event, item)"
                                 @click.right="onRightClickItem($event, item)">
                             <div class="list-metadata media-body">
@@ -1590,7 +1590,7 @@
 
                     <!-- Remaining metadata -->  
                     <div 
-                            class="media"
+                            class="media content"
                             @click.left="onClickItem($event, item)"
                             @click.right="onRightClickItem($event, item)">
                         <div 

--- a/src/views/admin/components/lists/items-list.vue
+++ b/src/views/admin/components/lists/items-list.vue
@@ -1224,7 +1224,7 @@
                                                 show: 500,
                                                 hide: 300,
                                             },
-                                            popperClass: [ 'tainacan-tooltip', 'tooltip', column.metadata_type_object != undefined && column.metadata_type_object.component == 'tainacan-textarea' ? 'metadata-type-textarea' : '', isRepositoryLevel ? 'tainacan-repository-tooltip' : ''],
+                                            popperClass: [ 'tainacan-tooltip', 'tooltip', 'content', column.metadata_type_object != undefined && column.metadata_type_object.component == 'tainacan-textarea' ? 'metadata-type-textarea' : '', isRepositoryLevel ? 'tainacan-repository-tooltip' : ''],
                                             content: renderMetadata(item.metadata, column) != '' ? renderMetadata(item.metadata, column) : `<span class='has-text-grey is-italic'>` + $i18n.get('label_value_not_provided') + `</span>`,
                                             html: true,
                                             autoHide: false,

--- a/src/views/admin/components/lists/items-list.vue
+++ b/src/views/admin/components/lists/items-list.vue
@@ -2649,7 +2649,7 @@ export default {
                         
                         if (this.viewMode == 'masonry' || this.viewMode == 'records') {
                             this.masonry = new Masonry( '.tainacan-' + this.viewMode + '-container', {
-                                itemSelector: 'li',
+                                itemSelector: this.viewMode == 'records' ? '.tainacan-records-container>li' : '.tainacan-masonry-container>li',
                                 columnWidth: '.tainacan-' + this.viewMode + '-grid-sizer',
                                 gutter: this.viewMode == 'masonry' ? 25 : 30,
                                 percentPosition: true,

--- a/src/views/admin/components/lists/related-items-list.vue
+++ b/src/views/admin/components/lists/related-items-list.vue
@@ -262,6 +262,10 @@
     }
     .related-items-list {
         .related-item-group {
+            text-align: start;
+            list-style: none;
+            margin-inline-start: 0;
+            padding-inline-start: 0;
 
             .related-item-group__items-list {
                 margin-top: 0.5em;

--- a/src/views/admin/components/metadata-types/compound/class-tainacan-compound.php
+++ b/src/views/admin/components/metadata-types/compound/class-tainacan-compound.php
@@ -191,31 +191,37 @@ class Compound extends Metadata_Type {
 		
 			if ( $item_metadata->is_multiple() ) {
 				$elements = [];
-				
 				foreach ( $value as $compound_element ) {
-					
 					if ( !empty($compound_element) ) {
 						$metadata_value =  array_fill(0, count($compound_element), null);
 						$metadata_value_not_ordinate = [];
-						
 						foreach ( $compound_element as $meta_id => $meta ) {
 							$index = array_search( $meta_id, array_column( $order, 'id' ) );
-							
 							if ( $meta instanceof Item_Metadata_Entity && $meta->get_value_as_html() != '' ) {
 								$html = $this->get_meta_html($meta);
-								
 								if ( $index !== false )
 									$metadata_value[$index] = $html;
 								else
 									$metadata_value_not_ordinate[] = $html;
 							}
 						}
-						$elements[] = '<div class="tainacan-compound-metadatum">' . implode("\n", array_merge($metadata_value, $metadata_value_not_ordinate)) . "</div> \n" ;
+						$elements[] = '<div class="tainacan-compound-metadatum">' . implode("\n", array_merge($metadata_value, $metadata_value_not_ordinate)) . "</div> \n";
 					}
 				}
-
-				$return = implode($separator, $elements);
-
+				$value_markup = $item_metadata->get_metadatum()->get_value_markup();
+				if ( $value_markup === 'list' ) {
+					if ( count( $elements ) === 1 ) {
+						$return = $elements[0];
+					} else {
+						$return = '<ul>';
+						foreach ( $elements as $el ) {
+							$return .= '<li>' . $el . '</li>';
+						}
+						$return .= '</ul>';
+					}
+				} else {
+					$return = implode($separator, $elements);
+				}
 			} else {
 				$metadata_value = array_fill(0, count($value), null);
 				$metadata_value_not_ordinate = [];

--- a/src/views/admin/components/metadata-types/compound/class-tainacan-compound.php
+++ b/src/views/admin/components/metadata-types/compound/class-tainacan-compound.php
@@ -190,7 +190,9 @@ class Compound extends Metadata_Type {
 		if ( !empty($value) ) { 
 		
 			if ( $item_metadata->is_multiple() ) {
+
 				$elements = [];
+
 				foreach ( $value as $compound_element ) {
 					if ( !empty($compound_element) ) {
 						$metadata_value =  array_fill(0, count($compound_element), null);
@@ -205,23 +207,26 @@ class Compound extends Metadata_Type {
 									$metadata_value_not_ordinate[] = $html;
 							}
 						}
-						$elements[] = '<div class="tainacan-compound-metadatum">' . implode("\n", array_merge($metadata_value, $metadata_value_not_ordinate)) . "</div> \n";
+						$elements[] = implode("\n", array_merge($metadata_value, $metadata_value_not_ordinate));
 					}
 				}
-				$value_markup = $item_metadata->get_metadatum()->get_value_markup();
-				if ( $value_markup === 'list' ) {
-					if ( count( $elements ) === 1 ) {
-						$return = $elements[0];
-					} else {
-						$return = '<ul>';
-						foreach ( $elements as $el ) {
-							$return .= '<li>' . $el . '</li>';
-						}
-						$return .= '</ul>';
+
+				$html_formatting = $item_metadata->get_metadatum()->get_html_formatting();
+				$render_multiple_as_list = $html_formatting === 'list' && count( $elements ) > 1;					
+				if ( $render_multiple_as_list ) {
+					$return = '<ul class="tainacan-compound-group">';
+					foreach ( $elements as $el ) {
+						$return .= '<li class="tainacan-compound-metadatum">' . $el . '</li>';
 					}
-				} else {
-					$return = implode($separator, $elements);
+					$return .= '</ul>';
+				} else  {
+					$return = '<div class="tainacan-compound-group">';
+					foreach ( $elements as $el ) {
+						$return .= '<div class="tainacan-compound-metadatum">' . $el . "</div> \n";
+					}
+					$return .= '</div>';
 				}
+				
 			} else {
 				$metadata_value = array_fill(0, count($value), null);
 				$metadata_value_not_ordinate = [];
@@ -240,9 +245,8 @@ class Compound extends Metadata_Type {
 				}
 
 				$return = implode("\n", array_merge($metadata_value, $metadata_value_not_ordinate));
-			}
-			
-			$return = "<div class='tainacan-compound-group'> {$return} </div>";
+				$return = "<div class='tainacan-compound-group'> {$return} </div>";
+			}	
 		}
 
 		return 

--- a/src/views/admin/components/metadata-types/compound/class-tainacan-compound.php
+++ b/src/views/admin/components/metadata-types/compound/class-tainacan-compound.php
@@ -220,9 +220,15 @@ class Compound extends Metadata_Type {
 					}
 					$return .= '</ul>';
 				} else  {
+					$total = count($elements);
+					$count = 0;
 					$return = '<div class="tainacan-compound-group">';
 					foreach ( $elements as $el ) {
 						$return .= '<div class="tainacan-compound-metadatum">' . $el . "</div> \n";
+						$count++;
+						if ( $count < $total ) {
+							$return .= $separator;
+						}
 					}
 					$return .= '</div>';
 				}

--- a/src/views/admin/components/metadata-types/control/class-tainacan-control.php
+++ b/src/views/admin/components/metadata-types/control/class-tainacan-control.php
@@ -149,18 +149,32 @@ class Control extends Metadata_Type {
 		} else {
 
 			if ( $item_metadata->is_multiple() ) {
-				$total = sizeof($value);
-				$count = 0;
-				$prefix = $item_metadata->get_multivalue_prefix();
-				$suffix = $item_metadata->get_multivalue_suffix();
-				$separator = $item_metadata->get_multivalue_separator();
-				foreach ($value as $v) {
-					$return .= $prefix;
-					$return .= (string) $v;
-					$return .= $suffix;
-					$count ++;
-					if ($count < $total)
-						$return .= $separator;
+				$value_markup = $item_metadata->get_metadatum()->get_value_markup();
+				if ( $value_markup === 'list' ) {
+					if ( count( $value ) === 1 ) {
+						$return .= esc_html( (string) reset( $value ) );
+					} else {
+						$return .= '<ul>';
+						foreach ( $value as $v ) {
+							$return .= '<li>' . esc_html( (string) $v ) . '</li>';
+						}
+						$return .= '</ul>';
+					}
+				} else {
+					$total = sizeof($value);
+					$count = 0;
+					$prefix = $item_metadata->get_multivalue_prefix();
+					$suffix = $item_metadata->get_multivalue_suffix();
+					$separator = $item_metadata->get_multivalue_separator();
+					foreach ( $value as $v ) {
+						$return .= $prefix;
+						$return .= (string) $v;
+						$return .= $suffix;
+						$count++;
+						if ( $count < $total ) {
+							$return .= $separator;
+						}
+					}
 				}
 			} else {
 				$return = (string) $value;

--- a/src/views/admin/components/metadata-types/control/class-tainacan-control.php
+++ b/src/views/admin/components/metadata-types/control/class-tainacan-control.php
@@ -149,14 +149,14 @@ class Control extends Metadata_Type {
 		} else {
 
 			if ( $item_metadata->is_multiple() ) {
-				$value_markup = $item_metadata->get_metadatum()->get_value_markup();
-				if ( $value_markup === 'list' ) {
+				$html_formatting = $item_metadata->get_metadatum()->get_html_formatting();
+				if ( $html_formatting === 'list' ) {
 					if ( count( $value ) === 1 ) {
-						$return .= esc_html( (string) reset( $value ) );
+						$return .= ( (string) reset( $value ) );
 					} else {
 						$return .= '<ul>';
 						foreach ( $value as $v ) {
-							$return .= '<li>' . esc_html( (string) $v ) . '</li>';
+							$return .= '<li>' . ( (string) $v ) . '</li>';
 						}
 						$return .= '</ul>';
 					}

--- a/src/views/admin/components/metadata-types/control/class-tainacan-control.php
+++ b/src/views/admin/components/metadata-types/control/class-tainacan-control.php
@@ -151,9 +151,10 @@ class Control extends Metadata_Type {
 			if ( $item_metadata->is_multiple() ) {
 				$html_formatting = $item_metadata->get_metadatum()->get_html_formatting();
 				if ( $html_formatting === 'list' ) {
-					if ( count( $value ) === 1 ) {
+					$total = count( $value );
+					if ( $total === 1 ) {
 						$return .= ( (string) reset( $value ) );
-					} else {
+					} elseif ( $total > 1 ) {
 						$return .= '<ul>';
 						foreach ( $value as $v ) {
 							$return .= '<li>' . ( (string) $v ) . '</li>';

--- a/src/views/admin/components/metadata-types/core-description/class-tainacan-core-description.php
+++ b/src/views/admin/components/metadata-types/core-description/class-tainacan-core-description.php
@@ -95,9 +95,10 @@ class Core_Description extends Metadata_Type {
 		if ( $item_metadata->is_multiple() ) {
 			$html_formatting = $item_metadata->get_metadatum()->get_html_formatting();
 			if ( $html_formatting === 'list' ) {
-				if ( count( $value ) === 1 ) {
+				$total = count( $value );
+				if ( $total === 1 ) {
 					$return .= nl2br($this->make_clickable_links( reset( $value ) ));
-				} else {
+				} elseif ( $total > 1 ) {
 					$return .= '<ul>';
 					foreach ( $value as $el ) {
 						$return .= '<li>' . nl2br($this->make_clickable_links($el)) . '</li>';

--- a/src/views/admin/components/metadata-types/core-description/class-tainacan-core-description.php
+++ b/src/views/admin/components/metadata-types/core-description/class-tainacan-core-description.php
@@ -93,8 +93,8 @@ class Core_Description extends Metadata_Type {
 		$return = '';
 
 		if ( $item_metadata->is_multiple() ) {
-			$value_markup = $item_metadata->get_metadatum()->get_value_markup();
-			if ( $value_markup === 'list' ) {
+			$html_formatting = $item_metadata->get_metadatum()->get_html_formatting();
+			if ( $html_formatting === 'list' ) {
 				if ( count( $value ) === 1 ) {
 					$return .= nl2br($this->make_clickable_links( reset( $value ) ));
 				} else {

--- a/src/views/admin/components/metadata-types/core-description/class-tainacan-core-description.php
+++ b/src/views/admin/components/metadata-types/core-description/class-tainacan-core-description.php
@@ -93,20 +93,32 @@ class Core_Description extends Metadata_Type {
 		$return = '';
 
 		if ( $item_metadata->is_multiple() ) {
-			$total = sizeof($value);
-			$count = 0;
-			$prefix = $item_metadata->get_multivalue_prefix();
-			$suffix = $item_metadata->get_multivalue_suffix();
-			$separator = $item_metadata->get_multivalue_separator();
-
-			foreach ( $value as $el ) {
-				$return .= $prefix;
-				$return .= nl2br($this->make_clickable_links($el));
-				$return .= $suffix;
-				$count ++;
-
-				if ($count < $total)
-					$return .= $separator;
+			$value_markup = $item_metadata->get_metadatum()->get_value_markup();
+			if ( $value_markup === 'list' ) {
+				if ( count( $value ) === 1 ) {
+					$return .= nl2br($this->make_clickable_links( reset( $value ) ));
+				} else {
+					$return .= '<ul>';
+					foreach ( $value as $el ) {
+						$return .= '<li>' . nl2br($this->make_clickable_links($el)) . '</li>';
+					}
+					$return .= '</ul>';
+				}
+			} else {
+				$total = sizeof($value);
+				$count = 0;
+				$prefix = $item_metadata->get_multivalue_prefix();
+				$suffix = $item_metadata->get_multivalue_suffix();
+				$separator = $item_metadata->get_multivalue_separator();
+				foreach ( $value as $el ) {
+					$return .= $prefix;
+					$return .= nl2br($this->make_clickable_links($el));
+					$return .= $suffix;
+					$count++;
+					if ( $count < $total ) {
+						$return .= $separator;
+					}
+				}
 			}
 		} else {
 			$return = nl2br($this->make_clickable_links($value));

--- a/src/views/admin/components/metadata-types/date/class-tainacan-date.php
+++ b/src/views/admin/components/metadata-types/date/class-tainacan-date.php
@@ -75,8 +75,8 @@ class Date extends Metadata_Type {
 		$return = '';
 
 		if ( $item_metadata->is_multiple() ) {
-			$value_markup = $item_metadata->get_metadatum()->get_value_markup();
-			if ( $value_markup === 'list' ) {
+			$html_formatting = $item_metadata->get_metadatum()->get_html_formatting();
+			if ( $html_formatting === 'list' ) {
 				$list_items = [];
 				foreach ( $value as $el ) {
 					if ( empty( $el ) ) {

--- a/src/views/admin/components/metadata-types/date/class-tainacan-date.php
+++ b/src/views/admin/components/metadata-types/date/class-tainacan-date.php
@@ -84,9 +84,10 @@ class Date extends Metadata_Type {
 					}
 					$list_items[] = $this->format_date_value($el);
 				}
-				if ( count( $list_items ) === 1 ) {
+				$total = count( $list_items );
+				if ( $total === 1 ) {
 					$return .= $list_items[0];
-				} else {
+				} elseif ( $total > 1 ) {
 					$return .= '<ul>';
 					foreach ( $list_items as $item ) {
 						$return .= '<li>' . $item . '</li>';

--- a/src/views/admin/components/metadata-types/date/class-tainacan-date.php
+++ b/src/views/admin/components/metadata-types/date/class-tainacan-date.php
@@ -75,24 +75,42 @@ class Date extends Metadata_Type {
 		$return = '';
 
 		if ( $item_metadata->is_multiple() ) {
-			$total = sizeof($value);
-			$count = 0;
-			$prefix = $item_metadata->get_multivalue_prefix();
-			$suffix = $item_metadata->get_multivalue_suffix();
-			$separator = $item_metadata->get_multivalue_separator();
-
-			foreach ( $value as $el ) {
-
-				if( empty( $el ) ) 
-					continue;
-
-				$return .= $prefix;
-				$return .= $this->format_date_value($el);
-				$return .= $suffix;
-				$count ++;
-
-				if ($count < $total)
-					$return .= $separator;
+			$value_markup = $item_metadata->get_metadatum()->get_value_markup();
+			if ( $value_markup === 'list' ) {
+				$list_items = [];
+				foreach ( $value as $el ) {
+					if ( empty( $el ) ) {
+						continue;
+					}
+					$list_items[] = $this->format_date_value($el);
+				}
+				if ( count( $list_items ) === 1 ) {
+					$return .= $list_items[0];
+				} else {
+					$return .= '<ul>';
+					foreach ( $list_items as $item ) {
+						$return .= '<li>' . $item . '</li>';
+					}
+					$return .= '</ul>';
+				}
+			} else {
+				$total = sizeof($value);
+				$count = 0;
+				$prefix = $item_metadata->get_multivalue_prefix();
+				$suffix = $item_metadata->get_multivalue_suffix();
+				$separator = $item_metadata->get_multivalue_separator();
+				foreach ( $value as $el ) {
+					if ( empty( $el ) ) {
+						continue;
+					}
+					$return .= $prefix;
+					$return .= $this->format_date_value($el);
+					$return .= $suffix;
+					$count++;
+					if ( $count < $total ) {
+						$return .= $separator;
+					}
+				}
 			}
 		} else {
 			$return = $this->format_date_value($value);

--- a/src/views/admin/components/metadata-types/geocoordinate/class-tainacan-geocoordinate.php
+++ b/src/views/admin/components/metadata-types/geocoordinate/class-tainacan-geocoordinate.php
@@ -162,26 +162,47 @@ class GeoCoordinate extends Metadata_Type {
 			$zoom_geo_query = isset($options['initial_zoom']) ? ('z=' . $options['initial_zoom'] ) : '' ;
 
 			if ( $item_metadata->is_multiple() ) {
-				$prefix = $item_metadata->get_multivalue_prefix();
-				$suffix = $item_metadata->get_multivalue_suffix();
-				$separator = $item_metadata->get_multivalue_separator();
-				
-				foreach ( $value as $coordinate ) {
-
-					$coordinate_as_array = explode(",", $coordinate);
-					$latitude = isset($coordinate_as_array[0]) ? $coordinate_as_array[0] : '';
-					$longitude = isset($coordinate_as_array[1]) ? $coordinate_as_array[1] : '';
-
-					$single_value = "<a class='tainacan-coordinates' data-latitude='{$latitude}' data-longitude='{$longitude}' href='geo:{$latitude},{$longitude}?q={$latitude},{$longitude}&{$zoom_geo_query}'>
-										<span>{$latitude}</span>
-										<span class='coordinates-separator'>,</span>
-										<span>{$longitude}</span>
-									</a>";
-					$return .= empty($return)
-						? $prefix . $single_value . $suffix
-						: $separator . $prefix . $single_value . $suffix;
+				$value_markup = $item_metadata->get_metadatum()->get_value_markup();
+				if ( $value_markup === 'list' ) {
+					$list_items = [];
+					foreach ( $value as $coordinate ) {
+						$coordinate_as_array = explode(",", $coordinate);
+						$latitude = isset($coordinate_as_array[0]) ? $coordinate_as_array[0] : '';
+						$longitude = isset($coordinate_as_array[1]) ? $coordinate_as_array[1] : '';
+						$single_value = "<a class='tainacan-coordinates' data-latitude='{$latitude}' data-longitude='{$longitude}' href='geo:{$latitude},{$longitude}?q={$latitude},{$longitude}&{$zoom_geo_query}'>
+											<span>{$latitude}</span>
+											<span class='coordinates-separator'>,</span>
+											<span>{$longitude}</span>
+										</a>";
+						$list_items[] = $single_value;
+					}
+					if ( count( $list_items ) === 1 ) {
+						$return .= $list_items[0];
+					} else {
+						$return .= '<ul>';
+						foreach ( $list_items as $item ) {
+							$return .= '<li>' . $item . '</li>';
+						}
+						$return .= '</ul>';
+					}
+				} else {
+					$prefix = $item_metadata->get_multivalue_prefix();
+					$suffix = $item_metadata->get_multivalue_suffix();
+					$separator = $item_metadata->get_multivalue_separator();
+					foreach ( $value as $coordinate ) {
+						$coordinate_as_array = explode(",", $coordinate);
+						$latitude = isset($coordinate_as_array[0]) ? $coordinate_as_array[0] : '';
+						$longitude = isset($coordinate_as_array[1]) ? $coordinate_as_array[1] : '';
+						$single_value = "<a class='tainacan-coordinates' data-latitude='{$latitude}' data-longitude='{$longitude}' href='geo:{$latitude},{$longitude}?q={$latitude},{$longitude}&{$zoom_geo_query}'>
+											<span>{$latitude}</span>
+											<span class='coordinates-separator'>,</span>
+											<span>{$longitude}</span>
+										</a>";
+						$return .= empty($return)
+							? $prefix . $single_value . $suffix
+							: $separator . $prefix . $single_value . $suffix;
+					}
 				}
-
 			} else {
 				$coordinate_as_array = explode(",", $value);
 				$latitude = isset($coordinate_as_array[0]) ? $coordinate_as_array[0] : '';

--- a/src/views/admin/components/metadata-types/geocoordinate/class-tainacan-geocoordinate.php
+++ b/src/views/admin/components/metadata-types/geocoordinate/class-tainacan-geocoordinate.php
@@ -162,8 +162,8 @@ class GeoCoordinate extends Metadata_Type {
 			$zoom_geo_query = isset($options['initial_zoom']) ? ('z=' . $options['initial_zoom'] ) : '' ;
 
 			if ( $item_metadata->is_multiple() ) {
-				$value_markup = $item_metadata->get_metadatum()->get_value_markup();
-				if ( $value_markup === 'list' ) {
+				$html_formatting = $item_metadata->get_metadatum()->get_html_formatting();
+				if ( $html_formatting === 'list' ) {
 					$list_items = [];
 					foreach ( $value as $coordinate ) {
 						$coordinate_as_array = explode(",", $coordinate);

--- a/src/views/admin/components/metadata-types/geocoordinate/class-tainacan-geocoordinate.php
+++ b/src/views/admin/components/metadata-types/geocoordinate/class-tainacan-geocoordinate.php
@@ -176,9 +176,10 @@ class GeoCoordinate extends Metadata_Type {
 										</a>";
 						$list_items[] = $single_value;
 					}
-					if ( count( $list_items ) === 1 ) {
+					$total = count( $list_items );
+					if ( $total === 1 ) {
 						$return .= $list_items[0];
-					} else {
+					} elseif ( $total > 1 ) {
 						$return .= '<ul>';
 						foreach ( $list_items as $item ) {
 							$return .= '<li>' . $item . '</li>';

--- a/src/views/admin/components/metadata-types/relationship/TainacanRelationship.vue
+++ b/src/views/admin/components/metadata-types/relationship/TainacanRelationship.vue
@@ -603,6 +603,7 @@
         transition: height 0.5s ease, min-height 0.5s ease;
 
         .tainacan-relationship-group {
+            
             &:not(:only-child) {
                 padding-bottom: 12px;
             }

--- a/src/views/admin/components/metadata-types/relationship/class-tainacan-relationship.php
+++ b/src/views/admin/components/metadata-types/relationship/class-tainacan-relationship.php
@@ -216,21 +216,45 @@ class Relationship extends Metadata_Type {
 		$return = '';
 
 		if ( $item_metadata->is_multiple() ) {
-			$prefix = $item_metadata->get_multivalue_prefix();
-			$suffix = $item_metadata->get_multivalue_suffix();
-			$separator = $item_metadata->get_multivalue_separator();
-			
-			foreach ( $value as $item_id ) {
-				try {
-					$Tainacan_Items = \Tainacan\Repositories\Items::get_instance();
-					$item = $Tainacan_Items->fetch( (int) $item_id);
-					if ( $this->can_display_item($item) ) {
-						$return .= empty($return)
-							? ($prefix . $this->get_item_html($item, $search_meta_id, $display_metas) . $suffix)
-							: ($separator . $prefix . $this->get_item_html($item, $search_meta_id, $display_metas) . $suffix);
+			$value_markup = $item_metadata->get_metadatum()->get_value_markup();
+			if ( $value_markup === 'list' ) {
+				$list_items = [];
+				foreach ( $value as $item_id ) {
+					try {
+						$Tainacan_Items = \Tainacan\Repositories\Items::get_instance();
+						$item = $Tainacan_Items->fetch( (int) $item_id);
+						if ( $this->can_display_item($item) ) {
+							$list_items[] = $this->get_item_html($item, $search_meta_id, $display_metas);
+						}
+					} catch (\Exception $e) {
+						// item not found
 					}
-				} catch (\Exception $e) {
-					// item not found
+				}
+				if ( count( $list_items ) === 1 ) {
+					$return .= $list_items[0];
+				} else {
+					$return .= '<ul>';
+					foreach ( $list_items as $item ) {
+						$return .= '<li>' . $item . '</li>';
+					}
+					$return .= '</ul>';
+				}
+			} else {
+				$prefix = $item_metadata->get_multivalue_prefix();
+				$suffix = $item_metadata->get_multivalue_suffix();
+				$separator = $item_metadata->get_multivalue_separator();
+				foreach ( $value as $item_id ) {
+					try {
+						$Tainacan_Items = \Tainacan\Repositories\Items::get_instance();
+						$item = $Tainacan_Items->fetch( (int) $item_id);
+						if ( $this->can_display_item($item) ) {
+							$return .= empty($return)
+								? ($prefix . $this->get_item_html($item, $search_meta_id, $display_metas) . $suffix)
+								: ($separator . $prefix . $this->get_item_html($item, $search_meta_id, $display_metas) . $suffix);
+						}
+					} catch (\Exception $e) {
+						// item not found
+					}
 				}
 			}
 		} else {

--- a/src/views/admin/components/metadata-types/relationship/class-tainacan-relationship.php
+++ b/src/views/admin/components/metadata-types/relationship/class-tainacan-relationship.php
@@ -216,28 +216,31 @@ class Relationship extends Metadata_Type {
 		$return = '';
 
 		if ( $item_metadata->is_multiple() ) {
-			$html_formatting = $item_metadata->get_metadatum()->get_html_formatting();
-			$render_multiple_as_list = $html_formatting === 'list' && count( $value ) > 1;
-			if ( $html_formatting === 'list' ) {
-				$list_items = [];
-				foreach ( $value as $item_id ) {
-					try {
-						$Tainacan_Items = \Tainacan\Repositories\Items::get_instance();
-						$item = $Tainacan_Items->fetch( (int) $item_id);
-						if ( $this->can_display_item($item) ) {
-							$list_items[] = $this->get_item_html($item, $search_meta_id, $display_metas, $render_multiple_as_list);
-						}
-					} catch (\Exception $e) {
-						// item not found
+			
+			$Tainacan_Items = \Tainacan\Repositories\Items::get_instance();
+			$items_to_display = [];
+			foreach ( (array) $value as $item_id ) {
+				try {
+					$item = $Tainacan_Items->fetch( (int) $item_id );
+					if ( $this->can_display_item($item) ) {
+						$items_to_display[] = $item;
 					}
+				} catch (\Exception $e) {
+					// skip invalid item
 				}
-				$total = count( $list_items );
+			}
+
+			$html_formatting = $item_metadata->get_metadatum()->get_html_formatting();
+			$render_multiple_as_list = $html_formatting === 'list' && count( $items_to_display ) > 1;
+			
+			if ( $html_formatting === 'list' ) {
+				$total = count( $items_to_display );
 				if ( $total === 1 ) {
-					$return = "<div class='tainacan-relationship-group'>{$list_items[0]}</div>";
+					$return = "<div class='tainacan-relationship-group'>{$this->get_item_html($items_to_display[0], $search_meta_id, $display_metas, $render_multiple_as_list)}</div>";
 				} elseif ( $total > 1 ) {
 					$return .= (!empty($display_metas) && is_array($display_metas) && count($display_metas) > 1 ) ? '<ul class="tainacan-relationship-group">' : '<ul>';
-					foreach ( $list_items as $item ) {
-						$return .= $item;
+					foreach ( $items_to_display as $item ) {
+						$return .= $this->get_item_html($item, $search_meta_id, $display_metas, $render_multiple_as_list);
 					}
 					$return .= '</ul>';
 				}
@@ -246,18 +249,11 @@ class Relationship extends Metadata_Type {
 				$prefix = $item_metadata->get_multivalue_prefix();
 				$suffix = $item_metadata->get_multivalue_suffix();
 				$separator = $item_metadata->get_multivalue_separator();
-				foreach ( $value as $item_id ) {
-					try {
-						$Tainacan_Items = \Tainacan\Repositories\Items::get_instance();
-						$item = $Tainacan_Items->fetch( (int) $item_id);
-						if ( $this->can_display_item($item) ) {
-							$return .= empty($return)
-								? ($prefix . $this->get_item_html($item, $search_meta_id, $display_metas) . $suffix)
-								: ($separator . $prefix . $this->get_item_html($item, $search_meta_id, $display_metas) . $suffix);
-						}
-					} catch (\Exception $e) {
-						// item not found
-					}
+
+				foreach ( $items_to_display as $item ) {
+					$return .= empty($return)
+						? ($prefix . $this->get_item_html($item, $search_meta_id, $display_metas) . $suffix)
+						: ($separator . $prefix . $this->get_item_html($item, $search_meta_id, $display_metas) . $suffix);
 				}
 				if ( !empty($display_metas) && is_array($display_metas) && count($display_metas) > 1 && $return !== '' ) {
 					$return = "<div class='tainacan-relationship-group'>{$return}</div>";

--- a/src/views/admin/components/metadata-types/relationship/class-tainacan-relationship.php
+++ b/src/views/admin/components/metadata-types/relationship/class-tainacan-relationship.php
@@ -217,6 +217,7 @@ class Relationship extends Metadata_Type {
 
 		if ( $item_metadata->is_multiple() ) {
 			$html_formatting = $item_metadata->get_metadatum()->get_html_formatting();
+			$render_multiple_as_list = $html_formatting === 'list' && count( $value ) > 1;
 			if ( $html_formatting === 'list' ) {
 				$list_items = [];
 				foreach ( $value as $item_id ) {
@@ -224,21 +225,22 @@ class Relationship extends Metadata_Type {
 						$Tainacan_Items = \Tainacan\Repositories\Items::get_instance();
 						$item = $Tainacan_Items->fetch( (int) $item_id);
 						if ( $this->can_display_item($item) ) {
-							$list_items[] = $this->get_item_html($item, $search_meta_id, $display_metas);
+							$list_items[] = $this->get_item_html($item, $search_meta_id, $display_metas, $render_multiple_as_list);
 						}
 					} catch (\Exception $e) {
 						// item not found
 					}
 				}
 				if ( count( $list_items ) === 1 ) {
-					$return .= $list_items[0];
+					$return = "<div class='tainacan-relationship-group'>{$list_items[0]}</div>";
 				} else {
-					$return .= '<ul>';
+					$return .= (!empty($display_metas) && is_array($display_metas) && count($display_metas) > 1 ) ? '<ul class="tainacan-relationship-group">' : '<ul>';
 					foreach ( $list_items as $item ) {
-						$return .= '<li>' . $item . '</li>';
+						$return .= $item;
 					}
 					$return .= '</ul>';
 				}
+
 			} else {
 				$prefix = $item_metadata->get_multivalue_prefix();
 				$suffix = $item_metadata->get_multivalue_suffix();
@@ -256,6 +258,9 @@ class Relationship extends Metadata_Type {
 						// item not found
 					}
 				}
+				if ( !empty($display_metas) && is_array($display_metas) && count($display_metas) > 1 && $return !== '' ) {
+					$return = "<div class='tainacan-relationship-group'>{$return}</div>";
+				}
 			}
 		} else {
 			try {
@@ -266,9 +271,10 @@ class Relationship extends Metadata_Type {
 			} catch (\Exception $e) {
 				// item not found 
 			}
-		}
-		if ( !empty($display_metas) && is_array($display_metas) && count($display_metas) > 1 && $return !== '' ) {
-			$return = "<div class='tainacan-relationship-group'>{$return}</div>";
+
+			if ( !empty($display_metas) && is_array($display_metas) && count($display_metas) > 1 && $return !== '' ) {
+				$return = "<div class='tainacan-relationship-group'>{$return}</div>";
+			}
 		}
 
 		return 
@@ -295,7 +301,7 @@ class Relationship extends Metadata_Type {
 		);
 	}
 
-	private function get_item_html($item, $search_meta_id, $display_metas) {
+	private function get_item_html($item, $search_meta_id, $display_metas, $render_as_list_item = false) {
 		$return = '';
 		$id = $item->get_id();
 		
@@ -322,7 +328,11 @@ class Relationship extends Metadata_Type {
 				}
 				$return = implode("\n", $metadata_value);
 			}
-			$return = "<div class='tainacan-relationship-metadatum' data-item-id='$id'>{$return}</div>";
+			if ( $render_as_list_item ) {
+				$return = "<li class='tainacan-relationship-metadatum' data-item-id='$id'>{$return}</li>";
+			} else {
+				$return = "<div class='tainacan-relationship-metadatum' data-item-id='$id'>{$return}</div>";
+			}
 		} else if ( $id && $search_meta_id ) {
 			$as_link = $this->get_item_link($item, $search_meta_id);
 			$return = "$as_link";

--- a/src/views/admin/components/metadata-types/relationship/class-tainacan-relationship.php
+++ b/src/views/admin/components/metadata-types/relationship/class-tainacan-relationship.php
@@ -332,7 +332,7 @@ class Relationship extends Metadata_Type {
 			}
 		} else if ( $id && $search_meta_id ) {
 			$as_link = $this->get_item_link($item, $search_meta_id);
-			$return = "$as_link";
+			$return = $render_as_list_item ? "<li>{$as_link}</li>" : "{$as_link}";
 		}
 
 		return $return;

--- a/src/views/admin/components/metadata-types/relationship/class-tainacan-relationship.php
+++ b/src/views/admin/components/metadata-types/relationship/class-tainacan-relationship.php
@@ -216,8 +216,8 @@ class Relationship extends Metadata_Type {
 		$return = '';
 
 		if ( $item_metadata->is_multiple() ) {
-			$value_markup = $item_metadata->get_metadatum()->get_value_markup();
-			if ( $value_markup === 'list' ) {
+			$html_formatting = $item_metadata->get_metadatum()->get_html_formatting();
+			if ( $html_formatting === 'list' ) {
 				$list_items = [];
 				foreach ( $value as $item_id ) {
 					try {

--- a/src/views/admin/components/metadata-types/relationship/class-tainacan-relationship.php
+++ b/src/views/admin/components/metadata-types/relationship/class-tainacan-relationship.php
@@ -231,9 +231,10 @@ class Relationship extends Metadata_Type {
 						// item not found
 					}
 				}
-				if ( count( $list_items ) === 1 ) {
+				$total = count( $list_items );
+				if ( $total === 1 ) {
 					$return = "<div class='tainacan-relationship-group'>{$list_items[0]}</div>";
-				} else {
+				} elseif ( $total > 1 ) {
 					$return .= (!empty($display_metas) && is_array($display_metas) && count($display_metas) > 1 ) ? '<ul class="tainacan-relationship-group">' : '<ul>';
 					foreach ( $list_items as $item ) {
 						$return .= $item;

--- a/src/views/admin/components/metadata-types/relationship/class-tainacan-relationship.php
+++ b/src/views/admin/components/metadata-types/relationship/class-tainacan-relationship.php
@@ -236,7 +236,10 @@ class Relationship extends Metadata_Type {
 			if ( $html_formatting === 'list' ) {
 				$total = count( $items_to_display );
 				if ( $total === 1 ) {
-					$return = "<div class='tainacan-relationship-group'>{$this->get_item_html($items_to_display[0], $search_meta_id, $display_metas, $render_multiple_as_list)}</div>";
+					$return = $this->get_item_html($items_to_display[0], $search_meta_id, $display_metas, $render_multiple_as_list);
+					if ( !empty($display_metas) && is_array($display_metas) && count($display_metas) > 1 && $return !== '' ) {
+						$return = "<div class='tainacan-relationship-group'>{$return}</div>";
+					}
 				} elseif ( $total > 1 ) {
 					$return .= (!empty($display_metas) && is_array($display_metas) && count($display_metas) > 1 ) ? '<ul class="tainacan-relationship-group">' : '<ul>';
 					foreach ( $items_to_display as $item ) {

--- a/src/views/admin/components/metadata-types/taxonomy/class-tainacan-taxonomy.php
+++ b/src/views/admin/components/metadata-types/taxonomy/class-tainacan-taxonomy.php
@@ -366,8 +366,8 @@ class Taxonomy extends Metadata_Type {
 		if ( isset($value) ) {
 
 			if ( $item_metadata->is_multiple() ) {
-				$value_markup = $item_metadata->get_metadatum()->get_value_markup();
-				if ( $value_markup === 'list' ) {
+				$html_formatting = $item_metadata->get_metadatum()->get_html_formatting();
+				if ( $html_formatting === 'list' ) {
 					$list_items = [];
 					foreach ( $value as $term ) {
 						if ( is_integer($term) ) {

--- a/src/views/admin/components/metadata-types/taxonomy/class-tainacan-taxonomy.php
+++ b/src/views/admin/components/metadata-types/taxonomy/class-tainacan-taxonomy.php
@@ -527,19 +527,19 @@ class Taxonomy extends Metadata_Type {
 			return strcmp( $a->get_name(), $b->get_name() );
 		} );
 
-		return $this->render_terms_tree_level( $roots, $children_by_parent, $ids_to_include, $item );
+		return $this->render_terms_tree_level( $roots, $children_by_parent, $item );
 	}
 
 	/**
 	 * Renders one level of the term tree as <ul><li>...</li></ul>.
+	 * Caller must have already filtered to the desired terms and built children_by_parent.
 	 *
 	 * @param \Tainacan\Entities\Term[] $terms Terms at this level.
 	 * @param array $children_by_parent Map parent_id => Term[].
-	 * @param array $ids_to_include Set of term IDs to include.
 	 * @param \Tainacan\Entities\Item|null $item Optional item.
 	 * @return string HTML fragment.
 	 */
-	private function render_terms_tree_level( array $terms, array $children_by_parent, array $ids_to_include, \Tainacan\Entities\Item $item = null ) {
+	private function render_terms_tree_level( array $terms, array $children_by_parent, \Tainacan\Entities\Item $item = null ) {
 		if ( empty( $terms ) ) {
 			return '';
 		}
@@ -547,7 +547,7 @@ class Taxonomy extends Metadata_Type {
 		foreach ( $terms as $term ) {
 			$id = (int) $term->get_id();
 			$children = isset( $children_by_parent[ $id ] ) ? $children_by_parent[ $id ] : [];
-			$child_html = ! empty( $children ) ? $this->render_terms_tree_level( $children, $children_by_parent, $ids_to_include, $item ) : '';
+			$child_html = ! empty( $children ) ? $this->render_terms_tree_level( $children, $children_by_parent, $item ) : '';
 			$out .= '<li>' . $this->term_to_html( $term, $item );
 			if ( $child_html !== '' ) {
 				$out .= $child_html;

--- a/src/views/admin/components/metadata-types/taxonomy/class-tainacan-taxonomy.php
+++ b/src/views/admin/components/metadata-types/taxonomy/class-tainacan-taxonomy.php
@@ -366,26 +366,44 @@ class Taxonomy extends Metadata_Type {
 		if ( isset($value) ) {
 
 			if ( $item_metadata->is_multiple() ) {
-				$count = 1;
-				$total = sizeof($value);
-				$prefix = $item_metadata->get_multivalue_prefix();
-				$suffix = $item_metadata->get_multivalue_suffix();
-				$separator = $item_metadata->get_multivalue_separator();
-
-				foreach ( $value as $term ) {
-					$count++;
-
-					if ( is_integer($term) ) {
-						$term = \Tainacan\Repositories\Terms::get_instance()->fetch($term, $this->get_option('taxonomy_id'));
+				$value_markup = $item_metadata->get_metadatum()->get_value_markup();
+				if ( $value_markup === 'list' ) {
+					$list_items = [];
+					foreach ( $value as $term ) {
+						if ( is_integer($term) ) {
+							$term = \Tainacan\Repositories\Terms::get_instance()->fetch($term, $this->get_option('taxonomy_id'));
+						}
+						if ( $term instanceof \Tainacan\Entities\Term ) {
+							$list_items[] = $this->get_term_hierarchy_html($term, $item_metadata->get_item());
+						}
 					}
-
-					if ( $term instanceof \Tainacan\Entities\Term ) {
-						$return .= $prefix;
-						$return .= $this->get_term_hierarchy_html($term, $item_metadata->get_item());
-						$return .= $suffix;
-
-						if ( $count <= $total ) {
-							$return .= $separator;
+					if ( count( $list_items ) === 1 ) {
+						$return .= $list_items[0];
+					} else {
+						$return .= '<ul>';
+						foreach ( $list_items as $item ) {
+							$return .= '<li>' . $item . '</li>';
+						}
+						$return .= '</ul>';
+					}
+				} else {
+					$count = 1;
+					$total = sizeof($value);
+					$prefix = $item_metadata->get_multivalue_prefix();
+					$suffix = $item_metadata->get_multivalue_suffix();
+					$separator = $item_metadata->get_multivalue_separator();
+					foreach ( $value as $term ) {
+						$count++;
+						if ( is_integer($term) ) {
+							$term = \Tainacan\Repositories\Terms::get_instance()->fetch($term, $this->get_option('taxonomy_id'));
+						}
+						if ( $term instanceof \Tainacan\Entities\Term ) {
+							$return .= $prefix;
+							$return .= $this->get_term_hierarchy_html($term, $item_metadata->get_item());
+							$return .= $suffix;
+							if ( $count <= $total ) {
+								$return .= $separator;
+							}
 						}
 					}
 				}

--- a/src/views/admin/components/metadata-types/taxonomy/class-tainacan-taxonomy.php
+++ b/src/views/admin/components/metadata-types/taxonomy/class-tainacan-taxonomy.php
@@ -543,7 +543,7 @@ class Taxonomy extends Metadata_Type {
 		if ( empty( $terms ) ) {
 			return '';
 		}
-		$out = '<ul>';
+		$out = '<ul class="tainacan-taxonomy-tree-level">';
 		foreach ( $terms as $term ) {
 			$id = (int) $term->get_id();
 			$children = isset( $children_by_parent[ $id ] ) ? $children_by_parent[ $id ] : [];

--- a/src/views/admin/components/metadata-types/taxonomy/class-tainacan-taxonomy.php
+++ b/src/views/admin/components/metadata-types/taxonomy/class-tainacan-taxonomy.php
@@ -111,7 +111,7 @@ class Taxonomy extends Metadata_Type {
 			],
 			'hide_hierarchy_path' => [
 				'title' => __( 'Hide hierarchy path', 'tainacan' ),
-				'description' => __( 'Display only the current child term when showing values that belong to a term hierarchy.', 'tainacan' ),
+				'description' => __( 'Inline: display only the current term (no "Parent > Term" path). List: show a flat list of selected terms only, without nesting or ancestor terms.', 'tainacan' ),
 			],
 			'do_not_dispaly_term_as_link' => [
 				'title' => __( 'Do not display term as link', 'tainacan' ),
@@ -368,23 +368,25 @@ class Taxonomy extends Metadata_Type {
 			if ( $item_metadata->is_multiple() ) {
 				$html_formatting = $item_metadata->get_metadatum()->get_html_formatting();
 				if ( $html_formatting === 'list' ) {
-					$list_items = [];
+					$terms_repo = \Tainacan\Repositories\Terms::get_instance();
+					$taxonomy_id = $this->get_option('taxonomy_id');
+					$resolved_terms = [];
 					foreach ( $value as $term ) {
 						if ( is_integer($term) ) {
-							$term = \Tainacan\Repositories\Terms::get_instance()->fetch($term, $this->get_option('taxonomy_id'));
+							$term = $terms_repo->fetch($term, $taxonomy_id);
 						}
 						if ( $term instanceof \Tainacan\Entities\Term ) {
-							$list_items[] = $this->get_term_hierarchy_html($term, $item_metadata->get_item());
+							$resolved_terms[] = $term;
 						}
 					}
-					if ( count( $list_items ) === 1 ) {
-						$return .= $list_items[0];
-					} else {
-						$return .= '<ul>';
-						foreach ( $list_items as $item ) {
-							$return .= '<li>' . $item . '</li>';
+					if ( count( $resolved_terms ) === 1 ) {
+						$return .= $this->get_term_hierarchy_html($resolved_terms[0], $item_metadata->get_item());
+					} elseif ( count( $resolved_terms ) > 1 ) {
+						if ( $this->get_option('hide_hierarchy_path') === 'yes' ) {
+							$return .= $this->render_terms_flat_list($resolved_terms, $item_metadata->get_item());
+						} else {
+							$return .= $this->render_terms_hierarchy_tree($resolved_terms, $item_metadata->get_item());
 						}
-						$return .= '</ul>';
 					}
 				} else {
 					$count = 1;
@@ -424,6 +426,136 @@ class Taxonomy extends Metadata_Type {
 			 * @return string The HTML representation of the item metadatum value
 			 */
 			apply_filters( 'tainacan-item-metadata-get-value-as-html--type-taxonomy', $return, $item_metadata );
+	}
+
+	/**
+	 * Renders a flat <ul><li> list of the given terms only (no ancestors, no nesting).
+	 * Used when html_formatting is list and hide_hierarchy_path is yes.
+	 *
+	 * @param \Tainacan\Entities\Term[] $terms Selected terms only.
+	 * @param \Tainacan\Entities\Item|null $item Optional item for link context.
+	 * @return string HTML <ul><li>...</li></ul>.
+	 */
+	private function render_terms_flat_list( array $terms, \Tainacan\Entities\Item $item = null ) {
+		$out = '<ul>';
+		foreach ( $terms as $term ) {
+			$out .= '<li>' . $this->term_to_html( $term, $item ) . '</li>';
+		}
+		$out .= '</ul>';
+		return $out;
+	}
+
+	/**
+	 * Builds and returns an HTML list tree from multiple terms, including ancestors so hierarchy is shown without repeating parents.
+	 * Uses get_ancestors() and a single get_terms() call (like wp_list_categories with 'include') to avoid N+1 queries.
+	 *
+	 * @see https://developer.wordpress.org/reference/functions/wp_list_categories/
+	 * @param \Tainacan\Entities\Term[] $terms Selected terms (may be at any level).
+	 * @param \Tainacan\Entities\Item|null $item Optional item for link context.
+	 * @return string Nested <ul>/<li> markup.
+	 */
+	private function render_terms_hierarchy_tree( array $terms, \Tainacan\Entities\Item $item = null ) {
+		$taxonomy_id = $this->get_option('taxonomy_id');
+		$taxonomy_slug = \Tainacan\Repositories\Taxonomies::get_instance()->get_db_identifier_by_id( (int) $taxonomy_id );
+		if ( ! $taxonomy_slug || ! taxonomy_exists( $taxonomy_slug ) ) {
+			return '';
+		}
+
+		$ids_to_include = [];
+		foreach ( $terms as $term ) {
+			if ( ! $term instanceof \Tainacan\Entities\Term ) {
+				continue;
+			}
+			$id = (int) $term->get_id();
+			$ids_to_include[ $id ] = true;
+			foreach ( get_ancestors( $id, $taxonomy_slug, 'taxonomy' ) as $ancestor_id ) {
+				$ids_to_include[ (int) $ancestor_id ] = true;
+			}
+		}
+		$ids_to_include = array_keys( $ids_to_include );
+		if ( empty( $ids_to_include ) ) {
+			return '';
+		}
+
+		$wp_terms = get_terms( [
+			'taxonomy'   => $taxonomy_slug,
+			'include'    => $ids_to_include,
+			'hide_empty' => false,
+			'orderby'    => 'parent',
+			'order'      => 'ASC',
+		] );
+		if ( is_wp_error( $wp_terms ) || empty( $wp_terms ) ) {
+			return '';
+		}
+
+		$term_by_id = [];
+		foreach ( $wp_terms as $wp_term ) {
+			$term_by_id[ (int) $wp_term->term_id ] = new \Tainacan\Entities\Term( $wp_term, $taxonomy_slug );
+		}
+		$ids_to_include = array_fill_keys( $ids_to_include, true );
+
+		$children_by_parent = [];
+		foreach ( $term_by_id as $id => $term ) {
+			if ( ! isset( $ids_to_include[ $id ] ) ) {
+				continue;
+			}
+			$parent_id = (int) $term->get_parent();
+			if ( isset( $ids_to_include[ $parent_id ] ) ) {
+				if ( ! isset( $children_by_parent[ $parent_id ] ) ) {
+					$children_by_parent[ $parent_id ] = [];
+				}
+				$children_by_parent[ $parent_id ][] = $term;
+			}
+		}
+		foreach ( array_keys( $children_by_parent ) as $parent_id ) {
+			usort( $children_by_parent[ $parent_id ], function ( $a, $b ) {
+				return strcmp( $a->get_name(), $b->get_name() );
+			} );
+		}
+
+		$roots = [];
+		foreach ( $term_by_id as $id => $term ) {
+			if ( ! isset( $ids_to_include[ $id ] ) ) {
+				continue;
+			}
+			$parent_id = (int) $term->get_parent();
+			if ( $parent_id === 0 || ! isset( $ids_to_include[ $parent_id ] ) ) {
+				$roots[] = $term;
+			}
+		}
+		usort( $roots, function ( $a, $b ) {
+			return strcmp( $a->get_name(), $b->get_name() );
+		} );
+
+		return $this->render_terms_tree_level( $roots, $children_by_parent, $ids_to_include, $item );
+	}
+
+	/**
+	 * Renders one level of the term tree as <ul><li>...</li></ul>.
+	 *
+	 * @param \Tainacan\Entities\Term[] $terms Terms at this level.
+	 * @param array $children_by_parent Map parent_id => Term[].
+	 * @param array $ids_to_include Set of term IDs to include.
+	 * @param \Tainacan\Entities\Item|null $item Optional item.
+	 * @return string HTML fragment.
+	 */
+	private function render_terms_tree_level( array $terms, array $children_by_parent, array $ids_to_include, \Tainacan\Entities\Item $item = null ) {
+		if ( empty( $terms ) ) {
+			return '';
+		}
+		$out = '<ul>';
+		foreach ( $terms as $term ) {
+			$id = (int) $term->get_id();
+			$children = isset( $children_by_parent[ $id ] ) ? $children_by_parent[ $id ] : [];
+			$child_html = ! empty( $children ) ? $this->render_terms_tree_level( $children, $children_by_parent, $ids_to_include, $item ) : '';
+			$out .= '<li>' . $this->term_to_html( $term, $item );
+			if ( $child_html !== '' ) {
+				$out .= $child_html;
+			}
+			$out .= '</li>';
+		}
+		$out .= '</ul>';
+		return $out;
 	}
 
 	private function get_term_hierarchy_html( \Tainacan\Entities\Term $term, \Tainacan\Entities\Item $item = null) {

--- a/src/views/admin/components/metadata-types/text/class-tainacan-text.php
+++ b/src/views/admin/components/metadata-types/text/class-tainacan-text.php
@@ -60,8 +60,8 @@ class Text extends Metadata_Type {
 		$return = '';
 
 		if ( is_array($value) && $item_metadata->is_multiple() ) {
-			$value_markup = $item_metadata->get_metadatum()->get_value_markup();
-			if ( $value_markup === 'list' ) {
+			$html_formatting = $item_metadata->get_metadatum()->get_html_formatting();
+			if ( $html_formatting === 'list' ) {
 				if ( count( $value ) === 1 ) {
 					$return .= $this->make_clickable_links( reset( $value ) );
 				} else {

--- a/src/views/admin/components/metadata-types/text/class-tainacan-text.php
+++ b/src/views/admin/components/metadata-types/text/class-tainacan-text.php
@@ -60,20 +60,32 @@ class Text extends Metadata_Type {
 		$return = '';
 
 		if ( is_array($value) && $item_metadata->is_multiple() ) {
-			$total = sizeof($value);
-			$count = 0;
-			$prefix = $item_metadata->get_multivalue_prefix();
-			$suffix = $item_metadata->get_multivalue_suffix();
-			$separator = $item_metadata->get_multivalue_separator();
-
-			foreach ( $value as $el ) {
-				$return .= $prefix;
-				$return .= $this->make_clickable_links($el);
-				$return .= $suffix;
-				$count ++;
-
-				if ($count < $total)
-					$return .= $separator;
+			$value_markup = $item_metadata->get_metadatum()->get_value_markup();
+			if ( $value_markup === 'list' ) {
+				if ( count( $value ) === 1 ) {
+					$return .= $this->make_clickable_links( reset( $value ) );
+				} else {
+					$return .= '<ul>';
+					foreach ( $value as $el ) {
+						$return .= '<li>' . $this->make_clickable_links($el) . '</li>';
+					}
+					$return .= '</ul>';
+				}
+			} else {
+				$total = sizeof($value);
+				$count = 0;
+				$prefix = $item_metadata->get_multivalue_prefix();
+				$suffix = $item_metadata->get_multivalue_suffix();
+				$separator = $item_metadata->get_multivalue_separator();
+				foreach ( $value as $el ) {
+					$return .= $prefix;
+					$return .= $this->make_clickable_links($el);
+					$return .= $suffix;
+					$count++;
+					if ( $count < $total ) {
+						$return .= $separator;
+					}
+				}
 			}
 		} else {
 			$return = $this->make_clickable_links($value);

--- a/src/views/admin/components/metadata-types/text/class-tainacan-text.php
+++ b/src/views/admin/components/metadata-types/text/class-tainacan-text.php
@@ -62,9 +62,10 @@ class Text extends Metadata_Type {
 		if ( is_array($value) && $item_metadata->is_multiple() ) {
 			$html_formatting = $item_metadata->get_metadatum()->get_html_formatting();
 			if ( $html_formatting === 'list' ) {
-				if ( count( $value ) === 1 ) {
+				$total = count( $value );
+				if ( $total === 1 ) {
 					$return .= $this->make_clickable_links( reset( $value ) );
-				} else {
+				} elseif ( $total > 1 ) {
 					$return .= '<ul>';
 					foreach ( $value as $el ) {
 						$return .= '<li>' . $this->make_clickable_links($el) . '</li>';

--- a/src/views/admin/components/metadata-types/textarea/class-tainacan-textarea.php
+++ b/src/views/admin/components/metadata-types/textarea/class-tainacan-textarea.php
@@ -57,20 +57,32 @@ class Textarea extends Metadata_Type {
 		$return = '';
 
 		if ( $item_metadata->is_multiple() ) {
-			$total = sizeof($value);
-			$count = 0;
-			$prefix = $item_metadata->get_multivalue_prefix();
-			$suffix = $item_metadata->get_multivalue_suffix();
-			$separator = $item_metadata->get_multivalue_separator();
-
-			foreach ( $value as $el ) {
-				$return .= $prefix;
-				$return .= nl2br($this->make_clickable_links($el));
-				$return .= $suffix;
-				$count ++;
-
-				if ($count < $total)
-					$return .= $separator;
+			$value_markup = $item_metadata->get_metadatum()->get_value_markup();
+			if ( $value_markup === 'list' ) {
+				if ( count( $value ) === 1 ) {
+					$return .= nl2br($this->make_clickable_links( reset( $value ) ));
+				} else {
+					$return .= '<ul>';
+					foreach ( $value as $el ) {
+						$return .= '<li>' . nl2br($this->make_clickable_links($el)) . '</li>';
+					}
+					$return .= '</ul>';
+				}
+			} else {
+				$total = sizeof($value);
+				$count = 0;
+				$prefix = $item_metadata->get_multivalue_prefix();
+				$suffix = $item_metadata->get_multivalue_suffix();
+				$separator = $item_metadata->get_multivalue_separator();
+				foreach ( $value as $el ) {
+					$return .= $prefix;
+					$return .= nl2br($this->make_clickable_links($el));
+					$return .= $suffix;
+					$count++;
+					if ( $count < $total ) {
+						$return .= $separator;
+					}
+				}
 			}
 		} else {
 			$return = nl2br($this->make_clickable_links($value));

--- a/src/views/admin/components/metadata-types/textarea/class-tainacan-textarea.php
+++ b/src/views/admin/components/metadata-types/textarea/class-tainacan-textarea.php
@@ -57,8 +57,8 @@ class Textarea extends Metadata_Type {
 		$return = '';
 
 		if ( $item_metadata->is_multiple() ) {
-			$value_markup = $item_metadata->get_metadatum()->get_value_markup();
-			if ( $value_markup === 'list' ) {
+			$html_formatting = $item_metadata->get_metadatum()->get_html_formatting();
+			if ( $html_formatting === 'list' ) {
 				if ( count( $value ) === 1 ) {
 					$return .= nl2br($this->make_clickable_links( reset( $value ) ));
 				} else {

--- a/src/views/admin/components/metadata-types/textarea/class-tainacan-textarea.php
+++ b/src/views/admin/components/metadata-types/textarea/class-tainacan-textarea.php
@@ -59,9 +59,10 @@ class Textarea extends Metadata_Type {
 		if ( $item_metadata->is_multiple() ) {
 			$html_formatting = $item_metadata->get_metadatum()->get_html_formatting();
 			if ( $html_formatting === 'list' ) {
-				if ( count( $value ) === 1 ) {
+				$total = count( $value );
+				if ( $total === 1 ) {
 					$return .= nl2br($this->make_clickable_links( reset( $value ) ));
-				} else {
+				} elseif ( $total > 1 ) {
 					$return .= '<ul>';
 					foreach ( $value as $el ) {
 						$return .= '<li>' . nl2br($this->make_clickable_links($el)) . '</li>';

--- a/src/views/admin/components/metadata-types/url/class-tainacan-url.php
+++ b/src/views/admin/components/metadata-types/url/class-tainacan-url.php
@@ -74,8 +74,8 @@ class URL extends Metadata_Type {
 		$return .= $link_as_button ? '<div class="wp-block-buttons">' : '';
 		
 		if ( is_array($value) && $item_metadata->is_multiple() ) {
-			$value_markup = $item_metadata->get_metadatum()->get_value_markup();
-			if ( $value_markup === 'list' ) {
+			$html_formatting = $item_metadata->get_metadatum()->get_html_formatting();
+			if ( $html_formatting === 'list' ) {
 				$list_items = [];
 				foreach ( $value as $el ) {
 					if ( !empty($el) ) {

--- a/src/views/admin/components/metadata-types/url/class-tainacan-url.php
+++ b/src/views/admin/components/metadata-types/url/class-tainacan-url.php
@@ -74,27 +74,41 @@ class URL extends Metadata_Type {
 		$return .= $link_as_button ? '<div class="wp-block-buttons">' : '';
 		
 		if ( is_array($value) && $item_metadata->is_multiple() ) {
-			$total = sizeof($value);
-			$count = 0;
-			$prefix = $item_metadata->get_multivalue_prefix();
-			$suffix = $item_metadata->get_multivalue_suffix();
-			$separator = $item_metadata->get_multivalue_separator();
-
-			foreach ( $value as $el ) {
-				if ( !empty($el) ) {
-					$return .= $prefix;
-					
-					$return .= $this->get_single_value_as_html($el);
-
-					$return .= $suffix;
-					
-					$count ++;
-
-					if ($count < $total && !$link_as_button)
-						$return .= $separator;
+			$value_markup = $item_metadata->get_metadatum()->get_value_markup();
+			if ( $value_markup === 'list' ) {
+				$list_items = [];
+				foreach ( $value as $el ) {
+					if ( !empty($el) ) {
+						$list_items[] = $this->get_single_value_as_html($el);
+					}
+				}
+				if ( count( $list_items ) === 1 ) {
+					$return .= $list_items[0];
+				} else {
+					$return .= '<ul>';
+					foreach ( $list_items as $item ) {
+						$return .= '<li>' . $item . '</li>';
+					}
+					$return .= '</ul>';
+				}
+			} else {
+				$total = sizeof($value);
+				$count = 0;
+				$prefix = $item_metadata->get_multivalue_prefix();
+				$suffix = $item_metadata->get_multivalue_suffix();
+				$separator = $item_metadata->get_multivalue_separator();
+				foreach ( $value as $el ) {
+					if ( !empty($el) ) {
+						$return .= $prefix;
+						$return .= $this->get_single_value_as_html($el);
+						$return .= $suffix;
+						$count++;
+						if ( $count < $total && !$link_as_button ) {
+							$return .= $separator;
+						}
+					}
 				}
 			}
-			
 		} else {			
 			$return .= $this->get_single_value_as_html($value);	
 		}

--- a/src/views/admin/components/metadata-types/url/class-tainacan-url.php
+++ b/src/views/admin/components/metadata-types/url/class-tainacan-url.php
@@ -82,9 +82,10 @@ class URL extends Metadata_Type {
 						$list_items[] = $this->get_single_value_as_html($el);
 					}
 				}
-				if ( count( $list_items ) === 1 ) {
+				$total = count( $list_items );
+				if ( $total === 1 ) {
 					$return .= $list_items[0];
-				} else {
+				} elseif ( $total > 1 ) {
 					$return .= '<ul>';
 					foreach ( $list_items as $item ) {
 						$return .= '<li>' . $item . '</li>';

--- a/src/views/admin/components/metadata-types/user/class-tainacan-user.php
+++ b/src/views/admin/components/metadata-types/user/class-tainacan-user.php
@@ -158,15 +158,27 @@ class User extends Metadata_Type {
 		$return = '';
 
 		if ( !empty($values) ) {
-			$values = is_array($values) ? $values: [$values];
+			$values = is_array($values) ? $values : [$values];
 			$response = [];
-			$multivalue_separator = $item_metadata->get_multivalue_separator();
-			
-			foreach($values as $value) {
+			foreach ( $values as $value ) {
 				$name = get_the_author_meta( 'display_name', $value );
 				$response[] = apply_filters("tainacan-item-get-author-name", $name, $this);
 			}
-			$return = implode($multivalue_separator, $response);
+			if ( count($response) > 1 ) {
+				$value_markup = $item_metadata->get_metadatum()->get_value_markup();
+				if ( $value_markup === 'list' ) {
+					$return .= '<ul>';
+					foreach ( $response as $name ) {
+						$return .= '<li>' . esc_html( $name ) . '</li>';
+					}
+					$return .= '</ul>';
+				} else {
+					$multivalue_separator = $item_metadata->get_multivalue_separator();
+					$return = implode($multivalue_separator, $response);
+				}
+			} else {
+				$return = implode('', $response);
+			}
 		}
 
 		return 

--- a/src/views/admin/components/metadata-types/user/class-tainacan-user.php
+++ b/src/views/admin/components/metadata-types/user/class-tainacan-user.php
@@ -165,11 +165,11 @@ class User extends Metadata_Type {
 				$response[] = apply_filters("tainacan-item-get-author-name", $name, $this);
 			}
 			if ( count($response) > 1 ) {
-				$value_markup = $item_metadata->get_metadatum()->get_value_markup();
-				if ( $value_markup === 'list' ) {
+				$html_formatting = $item_metadata->get_metadatum()->get_html_formatting();
+				if ( $html_formatting === 'list' ) {
 					$return .= '<ul>';
 					foreach ( $response as $name ) {
-						$return .= '<li>' . esc_html( $name ) . '</li>';
+						$return .= '<li>' . ( $name ) . '</li>';
 					}
 					$return .= '</ul>';
 				} else {

--- a/src/views/admin/scss/_tables.scss
+++ b/src/views/admin/scss/_tables.scss
@@ -274,6 +274,7 @@
                             white-space: nowrap;
                             overflow: hidden;
                             max-width: 100%;
+                            list-style: none;
                     
                             & * {
                                 display: inline;

--- a/src/views/admin/scss/_tables.scss
+++ b/src/views/admin/scss/_tables.scss
@@ -333,6 +333,27 @@
                                 line-height: 1.25em !important;
                             }
                         }   
+                        :deep(.tainacan-taxonomy-tree-level) {
+                            list-style: none;
+                            margin-inline-start: 0;
+                            padding-inline-start: 0;
+                            margin-bottom: 0;
+                            display: inline-block;
+                            margin-inline-start: 0.25em;
+
+                            li {
+                                display: inline-block;
+                                margin-inline-end: 0.25em;
+                            }
+                            ul > li:first-child::before {
+                                content: ' > ';
+                                color: var(--tainacan-gray3);
+                            }
+                            & > li:not(:last-child)::after {
+                                content: ' | ';
+                                color: var(--tainacan-gray3);
+                            }
+                        }
                     }
                     img.table-thumb,
                     .table-thumb>div {

--- a/src/views/admin/scss/_tables.scss
+++ b/src/views/admin/scss/_tables.scss
@@ -225,6 +225,9 @@
                             :deep(.tainacan-relationship-group) {
                                 display: inline-flex;
                                 align-items: center;
+                                list-style: none;
+                                margin-inline-start: 0;
+                                padding-inline-start: 0;
 
                                 & > .multivalue-separator {
                                     display: inline-block;
@@ -238,11 +241,31 @@
                                     align-items: center;
                                     max-height: 2.5em;
 
+                                    &:not(:last-child) {
+                                        border-inline-end: 1px solid var(--tainacan-gray2); 
+                                        padding-inline-end: 1em;
+                                        margin-inline-end: 1em;
+                                        margin-bottom: 0;
+                                        border-bottom: none;
+                                    }
+
                                     .tainacan-relationship-metadatum-header {
                                         display: inline-flex;
+                                        align-items: center;
 
                                         .label {
+                                            padding-top: 0;
+                                            padding-bottom: 0;
+                                            margin-top: 0;
+                                            margin-bottom: 0;
                                             font-size: 1.125em;
+                                        }
+
+                                        img {
+                                            margin-inline-end: 12px;
+                                            max-width: 22px !important;
+                                            max-height: 22px;
+                                            border-radius: var(--tainacan-item-border-radius, 0px);
                                         }
                                     }
                                     .tainacan-metadatum {
@@ -253,10 +276,16 @@
                                         .label {
                                             margin-top: 0;
                                             margin-bottom: 0;
+                                            padding-top: 0;
+                                            padding-bottom: 0;
                                             margin-inline-end: 0.5em;
                                             font-size: 0.95em;
                                         }
                                         p {
+                                            margin-top: 0;
+                                            margin-bottom: 0;
+                                            padding-top: 0;
+                                            padding-bottom: 0;
                                             font-size: 1.0em;
                                         }
                                     }

--- a/src/views/admin/scss/_tooltips.scss
+++ b/src/views/admin/scss/_tooltips.scss
@@ -194,13 +194,18 @@
             margin: 1em auto;
         }
     }
-    
+
     .tainacan-compound-group {
         text-align: start;
         list-style: none;
         margin-inline-start: 2px;
         padding-inline-start: 0.875em;
         border-inline-start: 1px solid var(--tainacan-gray2);
+
+        & > .tainacan-compound-metadatum:not(:last-child) {
+            border-bottom: 1px solid var(--tainacan-gray2);
+            margin-bottom: 1em;
+        }
 
         .tainacan-compound-metadatum .label {
             text-align: start;
@@ -226,6 +231,9 @@
     }
     .tainacan-relationship-group {
         text-align: start;
+        list-style: none;
+        margin-inline-start: 0;
+        padding-inline-start: 0;
         .tainacan-relationship-metadatum {
             text-align: start;
             .tainacan-relationship-metadatum-header {

--- a/src/views/admin/scss/_tooltips.scss
+++ b/src/views/admin/scss/_tooltips.scss
@@ -197,6 +197,7 @@
     
     .tainacan-compound-group {
         text-align: start;
+        list-style: none;
         margin-inline-start: 2px;
         padding-inline-start: 0.875em;
         border-inline-start: 1px solid var(--tainacan-gray2);
@@ -257,6 +258,7 @@
                 }
                 .tainacan-compound-group {
                     font-size: 1em;
+                    list-style: none;
                 }
             }
         }

--- a/src/views/admin/scss/tainacan-admin.scss
+++ b/src/views/admin/scss/tainacan-admin.scss
@@ -139,6 +139,7 @@ html.is-clipped .page-container:not(.is-filters-menu-open) {
 .metadata-value,
 .tainacan-relationship-group .tainacan-relationship-metadatum .tainacan-metadatum {
     .tainacan-compound-group {
+        list-style: none;
         margin-inline-start: 2px;
         padding-inline-start: 0.875em;
         border-inline-start: 1px solid var(--tainacan-gray2);
@@ -188,7 +189,7 @@ html.is-clipped .page-container:not(.is-filters-menu-open) {
         display: block;
         max-height: 1px;
         width: 80px;
-        background: var(--tainacan-gray3);
+        background: var(--tainacan-gray2);
         content: none;
         color: transparent;
         margin: 1em auto;
@@ -201,6 +202,16 @@ html.is-clipped .page-container:not(.is-filters-menu-open) {
     padding-inline-start: 15px;
     margin-inline-start: 0px;
     border-inline-start: 1px solid var(--tainacan-gray2);
+
+    .tainacan-compound-group {
+        list-style: none;
+        margin-inline-start: 0;
+
+        & > .tainacan-compound-metadatum:not(:last-child) {
+            border-bottom: 1px solid var(--tainacan-gray2);
+            margin-bottom: 1em;
+        }
+    }
 
     .tainacan-metadatum {
         margin-bottom: 0.75em;

--- a/src/views/admin/scss/tainacan-admin.scss
+++ b/src/views/admin/scss/tainacan-admin.scss
@@ -116,6 +116,11 @@ html.is-clipped .page-container:not(.is-filters-menu-open) {
 // Inside one of the view modes
 .metadata-value {
     .tainacan-relationship-group {
+        text-align: start;
+        list-style: none;
+        margin-inline-start: 0;
+        padding-inline-start: 0;
+
         .tainacan-relationship-metadatum {
             .tainacan-relationship-metadatum-header {
                 .label {
@@ -124,10 +129,11 @@ html.is-clipped .page-container:not(.is-filters-menu-open) {
                 img {
                     max-width: 22px !important;
                     max-height: 22px;
+                    border-radius: var(--tainacan-item-border-radius, 0px);
                 }
             }
-            .tainacan-metadatum {
-                margin-inline-start: 40px;
+            .tainacan-metadatum {   
+                margin-inline-start: 34px;
                 font-size: 1.125em;
                 &>*{
                     font-size: 0.875em;
@@ -143,6 +149,11 @@ html.is-clipped .page-container:not(.is-filters-menu-open) {
         margin-inline-start: 2px;
         padding-inline-start: 0.875em;
         border-inline-start: 1px solid var(--tainacan-gray2);
+
+        & > .tainacan-compound-metadatum:not(:last-child) {
+            border-bottom: 1px solid var(--tainacan-gray2);
+            margin-bottom: 1em;
+        }
 
         .tainacan-compound-metadatum .label {
             margin-bottom: 0.25em;
@@ -225,6 +236,11 @@ html.is-clipped .page-container:not(.is-filters-menu-open) {
     }
 }
 .tainacan-relationship-group {
+    text-align: start;
+    list-style: none;
+    margin-inline-start: 0;
+    padding-inline-start: 0;
+
     .tainacan-relationship-metadatum {
         .tainacan-relationship-metadatum-header {
             display: flex;
@@ -263,6 +279,16 @@ html.is-clipped .page-container:not(.is-filters-menu-open) {
         margin-block-start: 0.5em;
         margin-block-end: 0.5em;
         margin-inline-start: 40px;
+    }
+}
+ul.tainacan-relationship-group {
+    list-style: none;
+    margin-inline-start: 0;
+    padding-inline-start: 0;
+
+    & > .tainacan-relationship-metadatum:not(:last-child) {
+        border-bottom: 1px solid var(--tainacan-gray2);
+        margin-bottom: 1em;
     }
 }
 .taginput-container .input:hover {

--- a/src/views/gutenberg-blocks/blocks/dynamic-items-list/theme.vue
+++ b/src/views/gutenberg-blocks/blocks/dynamic-items-list/theme.vue
@@ -609,6 +609,7 @@ export default {
 
     .metadata-value {
         .tainacan-compound-group {
+            list-style: none;
             margin-inline-start: 2px;
             padding-inline-start: 0.875em;
             border-inline-start: 1px solid var(--tainacan-gray3);

--- a/src/views/gutenberg-blocks/blocks/dynamic-items-list/theme.vue
+++ b/src/views/gutenberg-blocks/blocks/dynamic-items-list/theme.vue
@@ -648,12 +648,6 @@ export default {
             padding-inline-start: 0;
 
             .tainacan-relationship-metadatum {
-
-                & > li.tainacan-relationship-metadatum:not(:last-child) {
-                    border-bottom: 1px solid var(--tainacan-gray2);
-                    margin-bottom: 1em;
-                }
-
                 .tainacan-relationship-metadatum-header {
                     display: flex;
                     align-items: center;
@@ -695,6 +689,16 @@ export default {
                 margin-block-start: 0.5em;
                 margin-block-end: 0.5em;
             }
+        }
+    }
+    ul.tainacan-relationship-group {
+        list-style: none;
+        margin-inline-start: 0;
+        padding-inline-start: 0;
+
+        & > .tainacan-relationship-metadatum:not(:last-child) {
+            border-bottom: 1px solid var(--tainacan-gray2);
+            margin-bottom: 1em;
         }
     }
 </style>

--- a/src/views/gutenberg-blocks/blocks/dynamic-items-list/theme.vue
+++ b/src/views/gutenberg-blocks/blocks/dynamic-items-list/theme.vue
@@ -613,6 +613,11 @@ export default {
             margin-inline-start: 2px;
             padding-inline-start: 0.875em;
             border-inline-start: 1px solid var(--tainacan-gray3);
+            
+            & > .tainacan-compound-metadatum:not(:last-child) {
+                border-bottom: 1px solid var(--tainacan-gray2);
+                margin-bottom: 1em;
+            }
 
             .tainacan-compound-metadatum .label {
                 margin-bottom: 0.25em;
@@ -637,7 +642,18 @@ export default {
             }
         }
         .tainacan-relationship-group {
+            text-align: start;
+            list-style: none;
+            margin-inline-start: 0;
+            padding-inline-start: 0;
+
             .tainacan-relationship-metadatum {
+
+                & > li.tainacan-relationship-metadatum:not(:last-child) {
+                    border-bottom: 1px solid var(--tainacan-gray2);
+                    margin-bottom: 1em;
+                }
+
                 .tainacan-relationship-metadatum-header {
                     display: flex;
                     align-items: center;
@@ -645,6 +661,7 @@ export default {
                         margin-inline-end: 12px;
                         max-width: 22px;
                         max-height: 22px;
+                        border-radius: var(--tainacan-item-border-radius, 0px);
                     }
                     .label {
                         font-weight: normal;
@@ -656,7 +673,7 @@ export default {
                     }
                 }
                 .tainacan-metadatum {
-                    margin-inline-start: 40px;
+                    margin-inline-start: 34px;
                     .label {
                         color: var(--tainacan-gray4);
                         font-size: 1em !important;
@@ -669,11 +686,11 @@ export default {
             &>.multivalue-separator {
                 display: block;
                 max-height: 1px;
-                width: calc(100% - 40px);
+                width: calc(100% - 34px);
                 background: var(--tainacan-gray2);
                 content: none;
                 color: transparent;
-                margin-inline-start: 40px;
+                margin-inline-start: 34px;
                 margin-inline-end: 0;
                 margin-block-start: 0.5em;
                 margin-block-end: 0.5em;

--- a/src/views/gutenberg-blocks/blocks/faceted-search/theme-search/components/view-mode-masonry.vue
+++ b/src/views/gutenberg-blocks/blocks/faceted-search/theme-search/components/view-mode-masonry.vue
@@ -114,7 +114,7 @@ export default {
                             this.masonry.destroy();
                         
                         this.masonry = new Masonry( this.containerId ? ( '#' + this.containerId + ' .tainacan-masonry-container' ) : '.tainacan-masonry-container', {
-                            itemSelector: 'li',
+                            itemSelector: '.tainacan-masonry-container>li',
                             columnWidth: '.tainacan-masonry-grid-sizer',
                             gutter: 25,
                             percentPosition: true,

--- a/src/views/gutenberg-blocks/blocks/faceted-search/theme-search/components/view-mode-records.vue
+++ b/src/views/gutenberg-blocks/blocks/faceted-search/theme-search/components/view-mode-records.vue
@@ -173,7 +173,7 @@ export default {
                             this.masonry.destroy();
                         
                         this.masonry = new Masonry( this.containerId ? ( '#' + this.containerId + ' .tainacan-records-container' ) : '.tainacan-records-container', {
-                            itemSelector: 'li',
+                            itemSelector: '.tainacan-records-container>li',
                             columnWidth: '.tainacan-records-grid-sizer',
                             gutter: 30,
                             percentPosition: true,

--- a/src/views/gutenberg-blocks/blocks/faceted-search/theme-search/components/view-mode-table.vue
+++ b/src/views/gutenberg-blocks/blocks/faceted-search/theme-search/components/view-mode-table.vue
@@ -312,6 +312,7 @@ export default {
         }
         .column-large-width {
             .tainacan-compound-group {
+                list-style: none;
                 display: inline-block;
                 font-size: 1.125em;
                 margin-top: -0.25em;

--- a/src/views/gutenberg-blocks/blocks/faceted-search/theme-search/components/view-mode-table.vue
+++ b/src/views/gutenberg-blocks/blocks/faceted-search/theme-search/components/view-mode-table.vue
@@ -280,6 +280,11 @@ export default {
     }
     .tainacan-table {
         .tainacan-relationship-group {
+            text-align: start;
+            list-style: none;
+            margin-inline-start: 0;
+            padding-inline-start: 0;
+            
             .tainacan-relationship-metadatum {
                 display: inline-block;
                 .tainacan-relationship-metadatum-header {

--- a/src/views/gutenberg-blocks/blocks/faceted-search/theme.vue
+++ b/src/views/gutenberg-blocks/blocks/faceted-search/theme.vue
@@ -1942,6 +1942,11 @@
                 padding-inline-start: 0.875em;
                 border-inline-start: 1px solid var(--tainacan-gray3);
 
+                & > .tainacan-compound-metadatum:not(:last-child) {
+                    border-bottom: 1px solid var(--tainacan-gray2);
+                    margin-bottom: 1em;
+                }
+
                 .tainacan-compound-metadatum .label {
                     margin-bottom: 0.25em;
                     font-size: 1em !important;
@@ -1968,26 +1973,37 @@
                 }
             }
             .tainacan-relationship-group {
+                text-align: start;
+                list-style: none;
+                margin-inline-start: 0;
+                padding-inline-start: 0;
+
+                & > li.tainacan-relationship-metadatum:not(:last-child) {
+                    border-bottom: 1px solid var(--tainacan-gray2);
+                    margin-bottom: 1em;
+                }
+                
                 .tainacan-relationship-metadatum {
                     .tainacan-relationship-metadatum-header {
                         display: flex;
                         align-items: center;
                         img {
-                            margin-right: 12px;
+                            margin-inline-end: 12px;
                             max-width: 22px;
                             max-height: 22px;
+                            border-radius: var(--tainacan-item-border-radius, 0px);
                         }
                         .label {
                             font-weight: normal;
                             font-size: 1em !important;
                             margin-top: 0;
-                            margin-left: 0;
+                            margin-inline-start: 0;
                             margin-bottom: 0;
-                            margin-right: 0;
+                            margin-inline-end: 0;
                         }
                     }
                     .tainacan-metadatum {
-                        margin-left: 40px;
+                        margin-inline-start: 34px;
                         .label {
                             color: var(--tainacan-gray4);
                             font-size: 1em !important;
@@ -2000,11 +2016,11 @@
                 &>.multivalue-separator {
                     display: block;
                     max-height: 1px;
-                    width: calc(100% - 40px);
+                    width: calc(100% - 34px);
                     background: var(--tainacan-gray2);
                     content: none;
                     color: transparent;
-                    margin: 0.5em 0 0.5em 40px;
+                    margin: 0.5em 0 0.5em 34px;
                 }
             }
         }

--- a/src/views/gutenberg-blocks/blocks/faceted-search/theme.vue
+++ b/src/views/gutenberg-blocks/blocks/faceted-search/theme.vue
@@ -1937,6 +1937,7 @@
 
         .metadata-value {
             .tainacan-compound-group {
+                list-style: none;
                 margin-inline-start: 2px;
                 padding-inline-start: 0.875em;
                 border-inline-start: 1px solid var(--tainacan-gray3);

--- a/src/views/gutenberg-blocks/blocks/item-submission-form/theme.vue
+++ b/src/views/gutenberg-blocks/blocks/item-submission-form/theme.vue
@@ -1394,6 +1394,7 @@ export default {
 
         .column-large-width {
             .tainacan-compound-group {
+                list-style: none;
                 display: inline-block;
                 font-size: 1.125em;
                 margin-top: -0.25em;
@@ -1434,6 +1435,7 @@ export default {
         .metadata-value {
                 
             .tainacan-compound-group {
+                list-style: none;
                 margin-inline-start: 2px;
                 padding-inline-start: 0.875em;
                 border-inline-start: 1px solid var(--tainacan-gray3);

--- a/src/views/tainacan-i18n.php
+++ b/src/views/tainacan-i18n.php
@@ -292,6 +292,8 @@ return apply_filters( 'tainacan-i18n', [
 	'label_display_default'                          => __( 'Display by default', 'tainacan' ),
 	'label_display_never'                            => __( 'Never displayed', 'tainacan' ),
 	'label_not_display'                              => __( 'Do not display by default', 'tainacan' ),
+	'label_value_markup_inline'                      => __( 'Inline', 'tainacan' ),
+	'label_value_markup_list'                        => __( 'List', 'tainacan' ),
 	'label_no_terms_selected'                        => __( 'No terms selected', 'tainacan' ),
 	'label_attach_to_item'                           => __( 'Attach to item', 'tainacan' ),
 	/* translators: Document is the main content of the Item. It can be a file, a url link or a text */

--- a/src/views/tainacan-i18n.php
+++ b/src/views/tainacan-i18n.php
@@ -292,8 +292,8 @@ return apply_filters( 'tainacan-i18n', [
 	'label_display_default'                          => __( 'Display by default', 'tainacan' ),
 	'label_display_never'                            => __( 'Never displayed', 'tainacan' ),
 	'label_not_display'                              => __( 'Do not display by default', 'tainacan' ),
-	'label_value_markup_inline'                      => __( 'Inline', 'tainacan' ),
-	'label_value_markup_list'                        => __( 'List', 'tainacan' ),
+	'label_html_formatting_inline'                      => __( 'Inline', 'tainacan' ),
+	'label_html_formatting_list'                        => __( 'List', 'tainacan' ),
 	'label_no_terms_selected'                        => __( 'No terms selected', 'tainacan' ),
 	'label_attach_to_item'                           => __( 'Attach to item', 'tainacan' ),
 	/* translators: Document is the main content of the Item. It can be a file, a url link or a text */


### PR DESCRIPTION
This branch adds a `html_formatting` option to display multivalued metadata as HTML lists (`<ul><li>`). Besides being more semantically accurate, it allows displaying Terms Hierarchy using nested lists. There isn't much styling of this since appearance should be themes territory so Tainacan Interface, Tainá and Blocksy will need to catch up a bit for this new feature.

- Every metadata may have the option defined as `inline` or `list`. `inline` is the default current behavior, which separates values by the `|` separator only; 
- When the `html_formatting` is `list` and the number of values is greater than 1, `<ul><li>` is used to wrap the elements and no separator is present;
- Compound is an exception, it renders multivalued metadata as `list` by default. We did this to improve the way Compound values are displayed in non-styled themes such as WordPress default ones. The Relationship metadata that use `display_related_item_metadata` options also benefit from this but the option must be set manually;
- Geocoordinate renders a list of coordinates instead of the unified map when `list` is used;
- Nested Taxonomy lists contain a `tainacan-taxonomy-tree-level` class in each `<ul>`;
- If the user wants to use `list` in a Taxonomy metadata where there is hierarchy without nesting, it can combine with the existing `hide_hierarchy_path` option;
- To allow nested HTML values inside their content, Records and Masonry view modes now initialize their Masonry library from more specific selectors than simply `li`;
- Some CSS tweaks were made to improve the display of complex metadata values inside tables and tooltips;

Closes #868.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes HTML output for many metadata types when `multiple` is enabled, which can impact theming, tooltips/tables rendering, and layout (Masonry selectors). Low security risk, but broad UI/output changes increase regression potential.
> 
> **Overview**
> Adds a new `html_formatting` metadatum property (validated/mapped in `Metadata` repository and exposed in the metadatum edition UI) to control how multi-valued fields are rendered: **`inline`** (current separator-based behavior) or **`list`** (`<ul><li>`). `Compound` metadata defaults to `list` when `multiple`.
> 
> Updates `get_value_as_html()` across multiple metadata types (including `Item_Metadata_Entity`, `Control`, `Text`, `Textarea`, `Core_Description`, `Date`, `URL`, `User`, `Relationship`, `Compound`, `Geocoordinate`, and `Taxonomy`) to honor `html_formatting`, including new nested taxonomy list rendering via `tainacan-taxonomy-tree-level`.
> 
> Adjusts list/records/masonry views to handle nested list markup (more specific Masonry `itemSelector`s) and tweaks admin/Gutenberg SCSS for tables and tooltips to style `<ul>`-based compound/relationship/taxonomy outputs more cleanly.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f012e59ed1e03551e7c3fd4b40c646219ea2a7ac. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->