### PR TITLE
Adds random order sorting to Dynamic Items List and Carousel Items List blocks

### DIFF
--- a/src/views/gutenberg-blocks/blocks/carousel-items-list/block.json
+++ b/src/views/gutenberg-blocks/blocks/carousel-items-list/block.json
@@ -130,6 +130,18 @@
             "type": "boolean",
             "default": false
         },
+        "order": {
+            "type": "string",
+            "default": ""
+        },
+        "orderBy": {
+            "type": "string",
+            "default": "date"
+        },
+        "orderByMetaKey": {
+            "type": "string",
+            "default": ""
+        },
         "style": {
             "type": "object",
             "default": {

--- a/src/views/gutenberg-blocks/blocks/carousel-items-list/edit.js
+++ b/src/views/gutenberg-blocks/blocks/carousel-items-list/edit.js
@@ -46,7 +46,10 @@ export default function({ attributes, setAttributes, isSelected, clientId }){
         collection,
         collectionBackgroundColor,
         collectionTextColor,
-        variableItemsWidth
+        variableItemsWidth,
+        order,
+        orderBy,
+        orderByMetaKey
     } = attributes;
 
     // Gets blocks props from hook
@@ -202,6 +205,40 @@ export default function({ attributes, setAttributes, isSelected, clientId }){
             else {
                 queryObject.perpage = 12;
                 setAttributes({ maxItemsNumber: 12 });
+            }
+
+            // Set up sorting order
+            if (queryObject.order != undefined && queryObject.order != '')
+                setAttributes({ order: queryObject.order });
+            else if (order != undefined && order != '')
+                queryObject.order = order;
+            else {
+                queryObject.order = 'asc';
+                setAttributes({ order: 'asc' });
+            }
+
+            // Set up sorting orderby
+            if (orderBy == 'rand') {
+                queryObject.orderby = 'rand';
+                if (queryObject.order != undefined && queryObject.order != '')
+                    delete queryObject.order;
+            } else if (queryObject.orderby != undefined && queryObject.orderby != '')
+                setAttributes({ orderBy: queryObject.orderby });
+            else if (orderBy != undefined && orderBy != 'date')
+                queryObject.orderby = orderBy;
+            else {
+                queryObject.orderby = 'date';
+                setAttributes({ orderBy: 'date' });
+            }
+
+            // Set up sorting metakey (used by some orderby)
+            if (queryObject.metakey != undefined && queryObject.metakey != '')
+                setAttributes({ orderByMetaKey: queryObject.metakey });
+            else if (orderByMetaKey != undefined && orderByMetaKey != '')
+                queryObject.metakey = orderByMetaKey;
+            else {
+                queryObject.metakey = '';
+                setAttributes({ orderByMetaKey: '' });
             }
 
             // Remove unecessary queries
@@ -560,6 +597,17 @@ export default function({ attributes, setAttributes, isSelected, clientId }){
                                     }}
                                     min={ 1 }
                                     max={ tainacan_blocks.api_max_items_per_page ? Number(tainacan_blocks.api_max_items_per_page) : 96 }
+                                />
+                                <hr></hr>
+                                <ToggleControl
+                                    label={__('Random order', 'tainacan')}
+                                    help={ orderBy == 'rand' ? __('Items will be ordered randomly.', 'tainacan') : __('Toggle to order items randomly.', 'tainacan')}
+                                    checked={ orderBy == 'rand' }
+                                    onChange={ ( isChecked ) => {
+                                        orderBy = isChecked ? 'rand' : 'date';
+                                        setAttributes({ orderBy: orderBy });
+                                        setContent();
+                                    } }
                                 />
                             </div>
                         </PanelBody>

--- a/src/views/gutenberg-blocks/blocks/carousel-items-list/save.js
+++ b/src/views/gutenberg-blocks/blocks/carousel-items-list/save.js
@@ -24,7 +24,10 @@ export default function ({ attributes }) {
         showCollectionLabel,
         collectionBackgroundColor,
         collectionTextColor,
-        variableItemsWidth
+        variableItemsWidth,
+        order,
+        orderBy,
+        orderByMetaKey
     } = attributes;
     
     // Gets attributes such as style, that are automatically added by the editor hook
@@ -55,6 +58,9 @@ export default function ({ attributes }) {
                 data-space-around-carousel={ spaceAroundCarousel }
                 data-tainacan-api-root={ tainacan_blocks.root }
                 data-variable-items-width={ '' + variableItemsWidth }
+                data-order={ order }
+                data-order-by={ orderBy }
+                data-order-by-meta-key={ orderByMetaKey }
                 id={ 'wp-block-tainacan-carousel-items-list_' + blockId }>
                     { content }
             </div>

--- a/src/views/gutenberg-blocks/blocks/carousel-items-list/theme.js
+++ b/src/views/gutenberg-blocks/blocks/carousel-items-list/theme.js
@@ -46,6 +46,9 @@ export default (element) => {
                             collectionTextColor: getDataAttribute(block, 'collection-text-color', '#ffffff'),
                             tainacanApiRoot: getDataAttribute(block, 'tainacan-api-root'),
                             variableItemsWidth: getDataAttribute(block, 'variable-items-width', false) == 'true',
+                            order: getDataAttribute(block, 'order', ''),
+                            orderBy: getDataAttribute(block, 'order-by', 'date'),
+                            orderByMetaKey: getDataAttribute(block, 'order-by-meta-key', ''),
                         });
                     },
                     mounted() {

--- a/src/views/gutenberg-blocks/blocks/carousel-items-list/theme.vue
+++ b/src/views/gutenberg-blocks/blocks/carousel-items-list/theme.vue
@@ -176,7 +176,10 @@ export default {
         collectionBackgroundColor: String,
         collectionTextColor: String,
         tainacanApiRoot: String,
-        variableItemsWidth: Boolean
+        variableItemsWidth: Boolean,
+        order: String,
+        orderBy: String,
+        orderByMetaKey: String
     },
     data() {
         return {
@@ -288,6 +291,12 @@ export default {
                     this.paged = queryObject.paged;
                 else
                     this.paged = 1;
+
+                // Set up sorting
+                if (this.orderBy != undefined)
+                    queryObject.orderby = this.orderBy;
+                if (this.order != undefined && this.orderBy !== 'rand')
+                    queryObject.order = this.order;
 
                 // Remove unecessary queries
                 delete queryObject.admin_view_mode;

--- a/src/views/gutenberg-blocks/blocks/dynamic-items-list/edit.js
+++ b/src/views/gutenberg-blocks/blocks/dynamic-items-list/edit.js
@@ -319,9 +319,9 @@ export default function({ attributes, setAttributes, isSelected, clientId }) {
             }
 
             // Set up sorting order
-            if (queryObject.order != '' && !showSearchBar)
+            if (queryObject.order != undefined && queryObject.order != '' && !showSearchBar)
                 setAttributes({ order: queryObject.order });
-            else if (order != '')
+            else if (order != undefined && order != '')
                 queryObject.order = order;
             else {
                 queryObject.order = 'asc';
@@ -329,9 +329,13 @@ export default function({ attributes, setAttributes, isSelected, clientId }) {
             }
             
             // Set up sorting orderby
-            if (queryObject.orderby != '')
+            if (orderBy == 'rand') {
+                queryObject.orderby = 'rand';
+                if (queryObject.order != undefined && queryObject.order != '')
+                    delete queryObject.order;
+            } else if (queryObject.orderby != undefined && queryObject.orderby != '')
                 setAttributes({ orderBy: queryObject.orderby });
-            else if (orderBy != 'date')
+            else if (orderBy != undefined && orderBy != 'date')
                 queryObject.orderby = orderBy;
             else {
                 queryObject.orderby = 'date';
@@ -339,9 +343,9 @@ export default function({ attributes, setAttributes, isSelected, clientId }) {
             }
 
             // Set up sorting metakey (used by some orderby)
-            if (queryObject.metakey != '')
+            if (queryObject.metakey != undefined && queryObject.metakey != '')
                 setAttributes({ orderByMetaKey: queryObject.metakey });
-            else if (orderByMetaKey != '')
+            else if (orderByMetaKey != undefined && orderByMetaKey != '')
                 queryObject.metakey = orderByMetaKey;
             else {
                 queryObject.metakey = '';
@@ -719,6 +723,16 @@ export default function({ attributes, setAttributes, isSelected, clientId }) {
                                     min={ 1 }
                                     max={ tainacan_blocks.api_max_items_per_page ? Number(tainacan_blocks.api_max_items_per_page) : 96 }
                                 />
+                                <ToggleControl
+                                    label={__('Random order', 'tainacan')}
+                                    help={ orderBy == 'rand' ? __('Items will be ordered randomly.', 'tainacan') : __('Toggle to order items randomly.', 'tainacan')}
+                                    checked={ orderBy == 'rand' }
+                                    onChange={ ( isChecked ) => {
+                                        orderBy = isChecked ? 'rand' : 'date';
+                                        setAttributes({ orderBy: orderBy });
+                                        setContent();
+                                    } }
+                                />
                             <hr></hr>
                         </div>
                          : null }
@@ -997,30 +1011,34 @@ export default function({ attributes, setAttributes, isSelected, clientId }) {
             {
                 showSearchBar ?
                 <div className="dynamic-items-search-bar">
-                    <Button
-                        onClick={ () => { order = 'asc'; setAttributes({ order: order }); setContent(); }}
-                        className={order == 'asc' ? 'sorting-button-selected' : ''}
-                        label={__('Sort ascending', 'tainacan')}>
-                        <span className="icon">
-                            <i>
-                                <svg width="24" height="24" viewBox="-2 -4 20 20">
-                                <path d="M6.7,10.8l-3.3,3.3L0,10.8h2.5V0h1.7v10.8H6.7z M11.7,0.8H8.3v1.7h3.3V0.8z M14.2,5.8H8.3v1.7h5.8V5.8z M16.7,10.8H8.3v1.7	h8.3V10.8z"/>       
-                                </svg>
-                            </i>
-                        </span>
-                    </Button>  
-                    <Button
-                        onClick={ () => { order = 'desc'; setAttributes({ order: order }); setContent(); }}
-                        className={order == 'desc' ? 'sorting-button-selected' : ''}
-                        label={__('Sort descending', 'tainacan')}>
-                        <span className="icon">
-                            <i>
-                                <svg width="24" height="24" viewBox="-2 -4 20 20">
-                                <path d="M6.7,3.3H4.2v10.8H2.5V3.3H0L3.3,0L6.7,3.3z M11.6,2.5H8.3v1.7h3.3V2.5z M14.1,7.5H8.3v1.7h5.8V7.5z M16.6,12.5H8.3v1.7 h8.3V12.5z"/>
-                                </svg>
-                            </i>
-                        </span>
-                    </Button>  
+                    { orderBy != 'rand' ?
+                        <>
+                            <Button
+                                onClick={ () => { order = 'asc'; setAttributes({ order: order }); setContent(); }}
+                                className={order == 'asc' ? 'sorting-button-selected' : ''}
+                                label={__('Sort ascending', 'tainacan')}>
+                                <span className="icon">
+                                    <i>
+                                        <svg width="24" height="24" viewBox="-2 -4 20 20">
+                                        <path d="M6.7,10.8l-3.3,3.3L0,10.8h2.5V0h1.7v10.8H6.7z M11.7,0.8H8.3v1.7h3.3V0.8z M14.2,5.8H8.3v1.7h5.8V5.8z M16.7,10.8H8.3v1.7	h8.3V10.8z"/>       
+                                        </svg>
+                                    </i>
+                                </span>
+                            </Button>  
+                            <Button
+                                onClick={ () => { order = 'desc'; setAttributes({ order: order }); setContent(); }}
+                                className={order == 'desc' ? 'sorting-button-selected' : ''}
+                                label={__('Sort descending', 'tainacan')}>
+                                <span className="icon">
+                                    <i>
+                                        <svg width="24" height="24" viewBox="-2 -4 20 20">
+                                        <path d="M6.7,3.3H4.2v10.8H2.5V3.3H0L3.3,0L6.7,3.3z M11.6,2.5H8.3v1.7h3.3V2.5z M14.1,7.5H8.3v1.7h5.8V7.5z M16.6,12.5H8.3v1.7 h8.3V12.5z"/>
+                                        </svg>
+                                    </i>
+                                </span>
+                            </Button>  
+                        </>
+                    : null }
                     <Button
                         onClick={ () => { setContent(); }}
                         label={__('Search', 'tainacan')}>

--- a/src/views/gutenberg-blocks/blocks/dynamic-items-list/theme.vue
+++ b/src/views/gutenberg-blocks/blocks/dynamic-items-list/theme.vue
@@ -48,6 +48,7 @@
             v-if="showSearchBar"
             class="dynamic-items-search-bar">
         <button
+                v-if="orderBy !== 'rand'"
                 :class="localOrder == 'asc' ? 'sorting-button-selected' : ''"
                 :label="wpI18n('Sort ascending', 'tainacan')"
                 @click="localOrder = 'asc'; fetchItems()">
@@ -65,6 +66,7 @@
             </span>
         </button>  
         <button
+                v-if="orderBy !== 'rand'"
                 :class="localOrder == 'desc' ? 'sorting-button-selected' : ''"
                 :label="wpI18n('Sort descending', 'tainacan')"
                 @click="localOrder = 'desc'; fetchItems(); ">
@@ -477,6 +479,10 @@ export default {
                 // Set up orderBy
                 if (this.orderBy != undefined)
                     queryObject.orderby = this.orderBy;
+
+                // Omit order when random
+                if (this.orderBy === 'rand')
+                    delete queryObject.order;
                 
                  // Set up orderByMetaKey
                 if (this.orderByMetaKey != undefined)

--- a/tests/test-random-sort-blocks.php
+++ b/tests/test-random-sort-blocks.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace Tainacan\Tests;
+
+/**
+ * @group api
+ */
+class TAINACAN_Random_Sort_Blocks extends TAINACAN_UnitApiTestCase {
+
+	public function test_api_fetch_items_with_orderby_rand() {
+		$collection = $this->tainacan_entity_factory->create_entity(
+			'collection',
+			[
+				'name'   => 'Random Sort Test Collection',
+				'status' => 'publish'
+			],
+			true
+		);
+
+		for ( $i = 0; $i < 3; $i++ ) {
+			$this->tainacan_entity_factory->create_entity(
+				'item',
+				[
+					'title'      => "Random Sort Item $i",
+					'collection' => $collection,
+					'status'     => 'publish'
+				],
+				true
+			);
+		}
+
+		$request = new \WP_REST_Request(
+			'GET', $this->namespace . '/collection/' . $collection->get_id() . '/items'
+		);
+		$request->set_query_params( [ 'orderby' => 'rand' ] );
+		$response = $this->server->dispatch( $request );
+
+		$this->assertEquals( 200, $response->get_status() );
+		$data = $response->get_data();
+		$this->assertArrayHasKey( 'items', $data );
+		$this->assertCount( 3, $data['items'] );
+	}
+}


### PR DESCRIPTION
Adds a "Random order" toggle to both Dynamic Items List and Carousel Items
List Gutenberg blocks, allowing items to be displayed in random order.

Changes:
- Adds "Random order" ToggleControl to both blocks (search mode only)
- Hides ascending/descending sort buttons when random is active
- Omits order param from API request when orderby=rand
- Adds order, orderBy, orderByMetaKey attributes to Carousel block
- Persists sorting attributes as data-* attributes in saved markup
- Prevents search URL orderby from overriding toggle value in setContent()
- Adds PHPUnit test verifying API accepts orderby=rand

Files modified:
- src/views/gutenberg-blocks/blocks/carousel-items-list/block.json
- src/views/gutenberg-blocks/blocks/carousel-items-list/edit.js
- src/views/gutenberg-blocks/blocks/carousel-items-list/save.js
- src/views/gutenberg-blocks/blocks/carousel-items-list/theme.js
- src/views/gutenberg-blocks/blocks/carousel-items-list/theme.vue
- src/views/gutenberg-blocks/blocks/dynamic-items-list/edit.js
- src/views/gutenberg-blocks/blocks/dynamic-items-list/theme.vue
- tests/test-random-sort-blocks.php

Closes #914