### PR TITLE
Add PR template and issue chooser config, fix README typo

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,8 @@
+blank_issues_enabled: true
+contact_links:
+  - name: 💬 Community forum
+    url: https://tainacan.discourse.group/
+    about: Ask questions and get support in English, Portuguese or Spanish.
+  - name: 📖 Developer documentation
+    url: https://tainacan.github.io/tainacan-wiki/#/dev/
+    about: Read the developer docs before contributing code.

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,30 @@
+## Description
+
+<!-- Describe the changes proposed in this PR. What does it do and why? -->
+
+## Related issue
+
+<!-- Link the issue this PR addresses, e.g. "Closes #123". -->
+
+Closes #
+
+## Type of change
+
+- [ ] Bug fix (non-breaking change which fixes an issue)
+- [ ] New feature (non-breaking change which adds functionality)
+- [ ] Breaking change (fix or feature that would change existing behavior)
+- [ ] Refactor / technical debt (no user-facing change)
+- [ ] Documentation
+
+## Checklist
+
+- [ ] My code follows the project's coding standards (ESLint / PHPCS)
+- [ ] I have tested my changes locally
+- [ ] I have added or updated tests when applicable
+- [ ] If I changed a Gutenberg block's `block.json` or `save.js`, I updated the corresponding `deprecated.js`
+- [ ] I have updated the documentation when needed
+- [ ] For UI changes, I have added screenshots or a screen recording below
+
+## Screenshots / recordings
+
+<!-- Optional: add screenshots or a short video for visual changes. -->

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 - Tainacan's [plugin](https://wordpress.org/plugins/tainacan/) and [theme](https://wordpress.org/themes/tainacan-interface/) on WordPress.org
 - [Access our website](http://tainacan.org)
 - [Read our official documentation](https://wiki.tainacan.org/)
-- [Conctact us in our forum](https://tainacan.discourse.group/)
+- [Contact us in our forum](https://tainacan.discourse.group/)
 - [Explore our blog](http://tainacan.org/blog/)
 - [Follow us on Twitter](https://twitter.com/tainacan_l3p)
 


### PR DESCRIPTION
## Description

Adds a pull request template and an issue template chooser config to the `.github` folder, and fixes a small typo in the README.

Files added:
- `.github/pull_request_template.md` — default PR body with description, linked issue, type of change and a Tainacan-specific checklist (including the `deprecated.js` reminder for Gutenberg block changes, based on the review feedback seen in #1051).
- `.github/ISSUE_TEMPLATE/config.yml` — adds forum and developer-docs links to the issue chooser and keeps blank issues enabled.

Files changed:
- `README.md` — fixed "Conctact" → "Contact".

## Related issue

Closes #1058 

## Type of change

- [x] Documentation
- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactor / technical debt

## Checklist

- [x] My code follows the project's coding standards
- [x] I have reviewed my own changes
- [x] This change is documentation/process only and requires no tests
- [x] N/A — no Gutenberg block changes
- [x] For UI changes, screenshots added (N/A — no UI changes)

## Notes

This contribution is part of a practical assignment for the Software Configuration and Evolution Management course (Gerência de Configuração e Evolução de Software - GCES) at the University of Brasília (UnB). Feedback on the template contents is very welcome, and I'm happy to iterate.