### PR TITLE
fix: Wrong link being created for editing and vieweing wp pages

### DIFF
--- a/src/views/admin/admin.vue
+++ b/src/views/admin/admin.vue
@@ -65,11 +65,11 @@
                     component: CustomDialog,
                     props: {
                         title: this.$i18n.get('error_permalinks_label'),
-                        message: this.$i18n.getWithVariables('error_permalinks_detail', [ tainacan_plugin.admin_url + 'options-permalink.php' ]),
+                        message: this.$i18n.getWithVariables('error_permalinks_detail', [ tainacan_plugin.wp_admin_url + 'options-permalink.php' ]),
                         hideCancel: true,
                         confirmText: this.$i18n.get('label_go_to_permalinks'),
                         onConfirm: () => {
-                            window.location.href = tainacan_plugin.admin_url.replace('/admin.php', '/options-permalink.php');
+                            window.location.href = tainacan_plugin.wp_admin_url + 'options-permalink.php';
                         }
                     },
                     ariaRole: 'alertdialog',
@@ -79,7 +79,7 @@
                 });
             },
             onHeartBitError(event, jqxhr, settings) {
-                if (settings && settings.url == tainacan_plugin.admin_url + 'admin-ajax.php') {
+                if (settings && settings.url == tainacan_plugin.wp_ajax_url) {
                     this.$buefy.snackbar.open({
                         message: this.$i18n.get('error_connectivity'),
                         type: 'is-danger',

--- a/src/views/admin/components/edition/collection-edition-form.vue
+++ b/src/views/admin/components/edition/collection-edition-form.vue
@@ -1190,7 +1190,7 @@ export default {
             fromImporter: '',
             repositoryEnabledViewModes: tainacan_plugin.enabled_view_modes,
             reCAPTCHASettingsPagePath: tainacan_plugin.admin_url + '?page=tainacan_item_submission',
-            newPagePath: tainacan_plugin.admin_url + 'post-new.php?post_type=page',
+            newPagePath: tainacan_plugin.wp_admin_url + 'post-new.php?post_type=page',
             isUpdatingSlug: false,
             entityName: 'collection',
             metadataSearchCancel: undefined,
@@ -1332,7 +1332,7 @@ export default {
                     .then((page) => {
                         this.coverPage = page;
                         this.coverPageTitle = this.coverPage.title.rendered;
-                        this.coverPageEditPath = tainacan_plugin.admin_url + '/post.php?post=' + page.id + '&action=edit';
+                        this.coverPageEditPath = tainacan_plugin.wp_admin_url + 'post.php?post=' + page.id + '&action=edit';
                         this.isFetchingPages = false;
                     })
                     .catch((error) => {
@@ -1685,7 +1685,7 @@ export default {
             this.form.cover_page_id = selectedPage.id; 
             this.coverPage = selectedPage;
             this.coverPageTitle = this.coverPage.title.rendered;
-            this.coverPageEditPath = tainacan_plugin.admin_url + 'post.php?post=' + selectedPage.id + '&action=edit';
+            this.coverPageEditPath = tainacan_plugin.wp_admin_url + 'post.php?post=' + selectedPage.id + '&action=edit';
         },
         removeCoverPage() {
             this.coverPage = {};

--- a/src/views/admin/components/edition/term-edition-form.vue
+++ b/src/views/admin/components/edition/term-edition-form.vue
@@ -398,7 +398,7 @@
                 coverPageTitle: '',
                 coverPageEditPath: '',
                 totalPages: 0,
-                newPagePath: tainacan_plugin.admin_url + 'post-new.php?post_type=page'
+                newPagePath: tainacan_plugin.wp_admin_url + 'post-new.php?post_type=page'
             }
         },
         created() {
@@ -449,7 +449,7 @@
                         this.coverPage = page;
                         if (this.coverPage && this.coverPage.title) {
                             this.coverPageTitle = this.coverPage.title.rendered;
-                            this.coverPageEditPath = tainacan_plugin.admin_url + 'post.php?post=' + page.id + '&action=edit';
+                            this.coverPageEditPath = tainacan_plugin.wp_admin_url + 'post.php?post=' + page.id + '&action=edit';
                         }
                         this.isFetchingPages = false;
                     })
@@ -699,7 +699,7 @@
                 this.form.cover_page_id = selectedPage.id; 
                 this.coverPage = selectedPage;
                 this.coverPageTitle = this.coverPage.title.rendered;
-                this.coverPageEditPath = tainacan_plugin.admin_url + 'post.php?post=' + selectedPage.id + '&action=edit';
+                this.coverPageEditPath = tainacan_plugin.wp_admin_url + 'post.php?post=' + selectedPage.id + '&action=edit';
             },
             removeCoverPage() {
                 this.coverPage = {};

--- a/src/views/class-tainacan-pages.php
+++ b/src/views/class-tainacan-pages.php
@@ -245,6 +245,7 @@ abstract class Pages {
 			'tainacan_api_url'         	=> esc_url_raw( rest_url() ) . 'tainacan/v2',
 			'wp_api_url'            	=> esc_url_raw( rest_url() ) . 'wp/v2/',
 			'wp_ajax_url'            	=> admin_url( 'admin-ajax.php' ),
+			'wp_admin_url'             	=> admin_url(),
 			'classes'                	=> array(),
 			'i18n'                   	=> $tainacan_admin_i18n,
 			'base_url'               	=> $TAINACAN_BASE_URL,


### PR DESCRIPTION
## Description

Links to WordPress Pages and Editor were being built wrongfully in the Collection and Term editing forms. They used `tainacan_plugin.admin_url` which had a suffix of `admin.php` already. This PR adds a new `tainacan_plugin.wp_admin_url` which is generated with `admin_url()`, allowing for concatenation in these situations.

## Related issue

Closes #1060.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would change existing behavior)
- [ ] Refactor / technical debt (no user-facing change)
- [ ] Documentation

## Checklist

- [x] My code follows the project's coding standards (ESLint / PHPCS)
- [x] I have tested my changes locally
- [x] I have added or updated tests when applicable
- [x] If I changed a Gutenberg block's `block.json` or `save.js`, I updated the corresponding `deprecated.js`
- [x] I have updated the documentation when needed