### PR TITLE
Resolução Issue 980

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,8 @@ Check out the digital exhibits in our [Showcase page](https://tainacan.org/en/ta
 
 In addition to [our documentation](https://wiki.tainacan.org/) and [instructional videos](https://youtu.be/oEl9bWe_rWI), we provide technical support on our [online forum](https://tainacan.discourse.group) in English, Portuguese and Spanish. You are welcome to send all of your questions!
 
+Inside the WordPress admin, Tainacan's main pages also provide contextual guidance in the native WordPress Help panel. Open a Tainacan admin page and click **Help** in the upper-right corner to see page-specific tips and documentation links.
+
 ### Developers
 
 Please refer to our [Developers Documentation](https://tainacan.github.io/tainacan-wiki/#/dev/) if you want to develop Tainacan plugins, themes or if you want to contribute to the core.

--- a/src/views/admin/class-tainacan-admin.php
+++ b/src/views/admin/class-tainacan-admin.php
@@ -255,6 +255,43 @@ class Admin extends Pages {
 
 	}
 
+	/**
+	 * Returns help tabs for the repository administration page.
+	 *
+	 * @return array
+	 */
+	protected function get_help_tabs() {
+		return array(
+			array(
+				'id'      => 'tainacan_repository_overview_help_tab',
+				'title'   => __( 'Repository', 'tainacan' ),
+				'content' => '<p>' . __( 'Use the Repository area to manage the structures shared by your digital repository, such as metadata, filters, taxonomies, activities, processes and reports.', 'tainacan' ) . '</p>',
+			),
+			array(
+				'id'      => 'tainacan_collections_overview_help_tab',
+				'title'   => __( 'Collections and items', 'tainacan' ),
+				'content' => '<p>' . __( 'Collections group items and define their metadata, filters and publication settings. The items pages let you browse, create and edit records across the repository or inside a specific collection.', 'tainacan' ) . '</p>',
+			),
+			array(
+				'id'      => 'tainacan_repository_tools_help_tab',
+				'title'   => __( 'Importers and exporters', 'tainacan' ),
+				'content' => '<p>' . __( 'Importers help you bring data into Tainacan, while exporters generate files from repository data. Long-running tasks can be followed from the Processes page.', 'tainacan' ) . '</p>',
+			),
+		);
+	}
+
+	/**
+	 * Returns help sidebar content for the repository administration page.
+	 *
+	 * @return string
+	 */
+	protected function get_help_sidebar() {
+		return
+			'<p><strong>' . __( 'For more information:', 'tainacan' ) . '</strong></p>' .
+			'<p><a href="' . esc_url( __( 'https://tainacan.github.io/tainacan-wiki/#/admin', 'tainacan' ) ) . '" target="_blank" rel="noopener noreferrer">' . __( 'Repository management', 'tainacan' ) . '</a></p>' .
+			'<p><a href="' . esc_url( __( 'https://tainacan.github.io/tainacan-wiki/#/collections', 'tainacan' ) ) . '" target="_blank" rel="noopener noreferrer">' . __( 'Collections', 'tainacan' ) . '</a></p>';
+	}
+
 	function admin_enqueue_js() {
 		global $TAINACAN_BASE_URL;
 		global $TAINACAN_EXTRA_SCRIPTS;

--- a/src/views/class-tainacan-pages.php
+++ b/src/views/class-tainacan-pages.php
@@ -66,6 +66,7 @@ abstract class Pages {
 		add_action( 'admin_enqueue_scripts', array( &$this, 'admin_enqueue_css' ), 90 );
 		add_action( 'admin_enqueue_scripts', array( &$this, 'admin_enqueue_js' ), 90 );
 		add_filter( 'screen_settings', array( &$this, 'admin_add_screen_options' ), 10, 2 );
+		$this->add_help_tabs();
 	}
 	
 	/**
@@ -79,6 +80,56 @@ abstract class Pages {
 	 * @return void
 	 */
 	function add_admin_menu() {}
+
+	/**
+	 * Returns the help tabs to be added to the current admin screen.
+	 *
+	 * @return array
+	 */
+	protected function get_help_tabs() {
+		return array();
+	}
+
+	/**
+	 * Returns the help sidebar content for the current admin screen.
+	 *
+	 * @return string
+	 */
+	protected function get_help_sidebar() {
+		return '';
+	}
+
+	/**
+	 * Adds WordPress help tabs and sidebar to the current admin screen.
+	 *
+	 * @return void
+	 */
+	protected function add_help_tabs() {
+		$screen = get_current_screen();
+
+		if ( ! $screen )
+			return;
+
+		$help_tabs = $this->get_help_tabs();
+
+		foreach ( $help_tabs as $help_tab ) {
+			if ( empty( $help_tab['id'] ) || empty( $help_tab['title'] ) || empty( $help_tab['content'] ) )
+				continue;
+
+			$screen->add_help_tab(
+				array(
+					'id'      => sanitize_key( $help_tab['id'] ),
+					'title'   => wp_strip_all_tags( $help_tab['title'] ),
+					'content' => wp_kses_post( $help_tab['content'] ),
+				)
+			);
+		}
+
+		$help_sidebar = $this->get_help_sidebar();
+
+		if ( ! empty( $help_sidebar ) )
+			$screen->set_help_sidebar( wp_kses_post( $help_sidebar ) );
+	}
 	
 	/**
 	 * admin_enqueue_css is called from the 'admin_enqueue_scripts' action only when the page is loaded and should

--- a/src/views/dashboard/class-tainacan-dashboard.php
+++ b/src/views/dashboard/class-tainacan-dashboard.php
@@ -92,18 +92,38 @@ class Dashboard extends Pages {
 
 		// Register Tainacan Cards using WordPress Widgets API
 		$this->register_cards();
+	}
 
-		// // Add help tabs if needed
-		// $screen->add_help_tab(array(
-		// 	'id' => 'tainacan_dashboard_help_tab',
-		// 	'title' => __('Dashboard Options', 'tainacan'),
-		// 	'content' => '<p>' . __('You can customize which cards appear on this dashboard.', 'tainacan') . '</p>',
-		// ));
+	/**
+	 * Returns help tabs for the dashboard page.
+	 *
+	 * @return array
+	 */
+	protected function get_help_tabs() {
+		return array(
+			array(
+				'id'      => 'tainacan_dashboard_overview_help_tab',
+				'title'   => __( 'Overview', 'tainacan' ),
+				'content' => '<p>' . __( 'The Tainacan dashboard brings together shortcuts, repository statistics, recent collections, news and links to learning resources.', 'tainacan' ) . '</p>',
+			),
+			array(
+				'id'      => 'tainacan_dashboard_options_help_tab',
+				'title'   => __( 'Dashboard cards', 'tainacan' ),
+				'content' => '<p>' . __( 'Use Screen Options to show or hide dashboard cards. When card sorting is enabled, you can drag cards to organize the dashboard for your workflow.', 'tainacan' ) . '</p>',
+			),
+		);
+	}
 
-		// $screen->set_help_sidebar(
-		// 	'<p>' . __('For more information:', 'tainacan') . '</p>' .
-		// 	'<p><a href="https://tainacan.org/" target="_blank">' . __('Tainacan Documentation', 'tainacan') . '</a></p>'
-		// );
+	/**
+	 * Returns help sidebar content for the dashboard page.
+	 *
+	 * @return string
+	 */
+	protected function get_help_sidebar() {
+		return
+			'<p><strong>' . __( 'For more information:', 'tainacan' ) . '</strong></p>' .
+			'<p><a href="' . esc_url( __( 'https://tainacan.github.io/tainacan-wiki/#/', 'tainacan' ) ) . '" target="_blank" rel="noopener noreferrer">' . __( 'Tainacan Documentation', 'tainacan' ) . '</a></p>' .
+			'<p><a href="' . esc_url( __( 'https://tainacan.github.io/tainacan-wiki/#/faq', 'tainacan' ) ) . '" target="_blank" rel="noopener noreferrer">' . __( 'Frequently Asked Questions', 'tainacan' ) . '</a></p>';
 	}
 
 	public function render_page_content() {

--- a/src/views/roles/class-tainacan-roles.php
+++ b/src/views/roles/class-tainacan-roles.php
@@ -33,6 +33,37 @@ class Roles_Editor extends Pages {
 		wp_enqueue_style( 'tainacan-roles-page', $TAINACAN_BASE_URL . '/assets/css/tainacan-roles.css', [], TAINACAN_VERSION );
 	}
 
+	/**
+	 * Returns help tabs for the user roles page.
+	 *
+	 * @return array
+	 */
+	protected function get_help_tabs() {
+		return array(
+			array(
+				'id'      => 'tainacan_roles_overview_help_tab',
+				'title'   => __( 'User roles', 'tainacan' ),
+				'content' => '<p>' . __( 'Use this page to review and adjust the Tainacan capabilities assigned to each WordPress user role.', 'tainacan' ) . '</p>',
+			),
+			array(
+				'id'      => 'tainacan_roles_capabilities_help_tab',
+				'title'   => __( 'Capabilities', 'tainacan' ),
+				'content' => '<p>' . __( 'Capabilities control who can manage repository structures, collections, items, taxonomies, processes and other administrative resources. Review changes carefully before saving.', 'tainacan' ) . '</p>',
+			),
+		);
+	}
+
+	/**
+	 * Returns help sidebar content for the user roles page.
+	 *
+	 * @return string
+	 */
+	protected function get_help_sidebar() {
+		return
+			'<p><strong>' . __( 'For more information:', 'tainacan' ) . '</strong></p>' .
+			'<p><a href="' . esc_url( __( 'https://tainacan.github.io/tainacan-wiki/#/permissions', 'tainacan' ) ) . '" target="_blank" rel="noopener noreferrer">' . __( 'Permissions and roles', 'tainacan' ) . '</a></p>';
+	}
+
 
 	function admin_enqueue_js() {
 		global $TAINACAN_BASE_URL;

--- a/src/views/settings/class-tainacan-settings.php
+++ b/src/views/settings/class-tainacan-settings.php
@@ -46,6 +46,38 @@ class Settings extends Pages {
 		wp_enqueue_style( 'tainacan-settings-page', $TAINACAN_BASE_URL . '/assets/css/tainacan-settings.css', [], TAINACAN_VERSION );
 	}
 
+	/**
+	 * Returns help tabs for the settings page.
+	 *
+	 * @return array
+	 */
+	protected function get_help_tabs() {
+		return array(
+			array(
+				'id'      => 'tainacan_settings_overview_help_tab',
+				'title'   => __( 'Settings', 'tainacan' ),
+				'content' => '<p>' . __( 'Use this page to configure repository-wide behavior, including search and performance, media processing, metadata, URLs and interface options.', 'tainacan' ) . '</p>',
+			),
+			array(
+				'id'      => 'tainacan_settings_constants_help_tab',
+				'title'   => __( 'Locked settings', 'tainacan' ),
+				'content' => '<p>' . __( 'Some settings can be locked by constants defined in the WordPress configuration. When this happens, the current value is shown here but can only be changed in the server configuration.', 'tainacan' ) . '</p>',
+			),
+		);
+	}
+
+	/**
+	 * Returns help sidebar content for the settings page.
+	 *
+	 * @return string
+	 */
+	protected function get_help_sidebar() {
+		return
+			'<p><strong>' . __( 'For more information:', 'tainacan' ) . '</strong></p>' .
+			'<p><a href="' . esc_url( __( 'https://tainacan.github.io/tainacan-wiki/#/settings', 'tainacan' ) ) . '" target="_blank" rel="noopener noreferrer">' . __( 'Tainacan settings', 'tainacan' ) . '</a></p>' .
+			'<p><a href="' . esc_url( __( 'https://tainacan.github.io/tainacan-wiki/#/dev', 'tainacan' ) ) . '" target="_blank" rel="noopener noreferrer">' . __( 'Developer documentation', 'tainacan' ) . '</a></p>';
+	}
+
 	public function render_page_content() {
 		require_once('page.php');
 	}

--- a/src/views/system-check/class-tainacan-system-check.php
+++ b/src/views/system-check/class-tainacan-system-check.php
@@ -45,6 +45,38 @@ class System_Check extends Pages {
 		require_once('page.php');
 	}
 
+	/**
+	 * Returns help tabs for the system check page.
+	 *
+	 * @return array
+	 */
+	protected function get_help_tabs() {
+		return array(
+			array(
+				'id'      => 'tainacan_system_check_overview_help_tab',
+				'title'   => __( 'System check', 'tainacan' ),
+				'content' => '<p>' . __( 'This page checks whether your WordPress installation, PHP environment, database and upload folders meet the requirements recommended for Tainacan.', 'tainacan' ) . '</p>',
+			),
+			array(
+				'id'      => 'tainacan_system_check_results_help_tab',
+				'title'   => __( 'Reading results', 'tainacan' ),
+				'content' => '<p>' . __( 'Warnings point to recommended improvements, while errors indicate requirements that may prevent Tainacan from working correctly. Server-related issues usually need to be handled by the site administrator or hosting provider.', 'tainacan' ) . '</p>',
+			),
+		);
+	}
+
+	/**
+	 * Returns help sidebar content for the system check page.
+	 *
+	 * @return string
+	 */
+	protected function get_help_sidebar() {
+		return
+			'<p><strong>' . __( 'For more information:', 'tainacan' ) . '</strong></p>' .
+			'<p><a href="' . esc_url( __( 'https://tainacan.github.io/tainacan-wiki/#/requirements', 'tainacan' ) ) . '" target="_blank" rel="noopener noreferrer">' . __( 'System requirements', 'tainacan' ) . '</a></p>' .
+			'<p><a href="' . esc_url( __( 'https://tainacan.github.io/tainacan-wiki/#/faq', 'tainacan' ) ) . '" target="_blank" rel="noopener noreferrer">' . __( 'Frequently Asked Questions', 'tainacan' ) . '</a></p>';
+	}
+
 	public function test_php_version() {
 		$testphpmin = version_compare( $this->min_php_version, PHP_VERSION, '<=' );
 		$testphprec = version_compare( '7.4', PHP_VERSION, '<=' );


### PR DESCRIPTION
## Description

Adds contextual help tabs to the main Tainacan admin pages using the native WordPress Help panel.

This PR adds a reusable help-tabs structure to the shared admin pages base class and provides page-specific help content and documentation links for:

- Dashboard
- Repository
- Settings
- User roles
- System check

It also updates the README to mention that contextual help is available from the WordPress admin Help panel.

## Related issue

Closes #980

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would change existing behavior)
- [x] Refactor / technical debt (no user-facing change)
- [x] Documentation

## Checklist

- [x] My code follows the project's coding standards (ESLint / PHPCS)
- [x] I have tested my changes locally
- [x] I have added or updated tests when applicable
- [x] If I changed a Gutenberg block's `block.json` or `save.js`, I updated the corresponding `deprecated.js`
- [x] I have updated the documentation when needed
- [x ] For UI changes, I have added screenshots or a screen recording below

## Screenshots / recordings

Not added yet. Visual verification requires opening a Tainacan admin page in WordPress and clicking the **Help** tab in the upper-right corner.