### PR TITLE
fix: Download button overflowing media gallery container due to chang…

### DIFF
--- a/src/views/gutenberg-blocks/blocks/item-gallery/style.scss
+++ b/src/views/gutenberg-blocks/blocks/item-gallery/style.scss
@@ -143,6 +143,9 @@
             a {
                 cursor: zoom-in !important;
             }
+            .tainacan-item-file-download {
+                z-index: 99;
+            }
             .tainacan-item-file-download a,
             .swiper-slide-metadata a {
                 cursor: pointer !important;
@@ -155,6 +158,8 @@
         max-width: 100%;
         width: 100%;
         opacity: 1.0;
+        position: relative;
+        z-index: 0;
         transition: opacity 0.2s linear;
 
         &.swiper-slide {
@@ -266,8 +271,8 @@
             background-repeat: no-repeat;
             background-position: center;
         }
-        a:first-of-type,
-        p:first-of-type {
+        & > a:first-of-type,
+        & > p:first-of-type {
             z-index: 99;
             background: var(--tainacan-media-background, #ffffff);
             border-radius: 3px;
@@ -275,8 +280,8 @@
             padding: 0rem 0rem;
             display: block;
         }
-        a:first-of-type:not(:has(img):not(:has(video)):not(:has(audio))),
-        p:first-of-type:not(:has(img):not(:has(video)):not(:has(audio))) {
+        & > a:first-of-type:not(:has(img):not(:has(video)):not(:has(audio))),
+        & > p:first-of-type:not(:has(img):not(:has(video)):not(:has(audio))) {
             padding: 0rem 2rem;
         }
         audio {
@@ -331,6 +336,8 @@
     }
 
     .tainacan-media-item {
+        position: relative;
+        z-index: 0;
         text-align: center;
         vertical-align: top;
         word-break: break-word;


### PR DESCRIPTION
…e of swiper classes.

## Description

Adds relative positioning to `.tainacan-media-item` since that used to be present in `.swiper-item` before the removal made in Tainacan 1.1.0. This restores the expected positioning behavior of the Download button.

The white background issue on Tainacan interface was caused due to new level of css specificity. The background color was originated from a rule that, after investigating, was considered not apropriate for first child `<a>` and `<p>` tags. Now the rule is applied only to direct children of the `.swiper-slide-content`.

## Related issue

Closes #1072 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would change existing behavior)
- [ ] Refactor / technical debt (no user-facing change)
- [ ] Documentation

## Checklist

- [x] My code follows the project's coding standards (ESLint / PHPCS)
- [x] I have tested my changes locally
- [] I have added or updated tests when applicable
- [] If I changed a Gutenberg block's `block.json` or `save.js`, I updated the corresponding `deprecated.js`
- [ ] I have updated the documentation when needed
- [ ] For UI changes, I have added screenshots or a screen recording below
