### PR TITLE
feat: Adds allowfullscreen option to document.

### DIFF
--- a/src/classes/entities/class-tainacan-item.php
+++ b/src/classes/entities/class-tainacan-item.php
@@ -934,8 +934,9 @@ class Item extends Entity {
 						$tainacan_embed = \Tainacan\Embed::get_instance();
 						$iframe_width = isset($document_options['forced_iframe_width']) ? $document_options['forced_iframe_width'] : '600';
 						$iframe_height = isset($document_options['forced_iframe_height']) ? $document_options['forced_iframe_height'] : '450';
+						$iframe_allowfullscreen = ! empty( $document_options['forced_iframe_allowfullscreen'] ) ? ' allowfullscreen' : '';
 
-						$_embed = $tainacan_embed->add_responsive_wrapper( sprintf('<iframe src="%s" style="border: 0" width="%s" height="%s"></iframe>', $url, $iframe_width, $iframe_height) );
+						$_embed = $tainacan_embed->add_responsive_wrapper( sprintf('<iframe src="%s" style="border: 0" width="%s" height="%s"%s></iframe>', $url, $iframe_width, $iframe_height, $iframe_allowfullscreen) );
 					}
 				} else {
 					$_embed = sprintf('<a href="%s" target="blank">%s</a>', $url, $url);

--- a/src/classes/repositories/class-tainacan-items.php
+++ b/src/classes/repositories/class-tainacan-items.php
@@ -145,6 +145,12 @@ class Items extends Repository {
 						'context'     => array( 'view', 'edit', 'embed' ),
 						'default'     => 600
 					),
+					'forced_iframe_allowfullscreen' => array(
+						'description' => __( 'Allow fullscreen on forced iframe', 'tainacan' ),
+						'type'        => 'boolean',
+						'context'     => array( 'view', 'edit', 'embed' ),
+						'default'     => false
+					),
 				)
 			],
 			'document_content_index'     => [

--- a/src/views/admin/components/edition/item-edition-form.vue
+++ b/src/views/admin/components/edition/item-edition-form.vue
@@ -920,6 +920,7 @@ export default {
             urlForcedIframe: false,
             urlIframeWidth: 600,
             urlIframeHeight: 450,
+            urlIframeAllowfullscreen: false,
             urlIsImage: false,
             isMobileScreen: false,
             openMetadataNameFilter: false,
@@ -1648,6 +1649,7 @@ export default {
                     urlForcedIframe: this.urlForcedIframe,
                     urlIframeWidth: this.urlIframeWidth,
                     urlIframeHeight: this.urlIframeHeight,
+                    urlIframeAllowfullscreen: this.urlIframeAllowfullscreen,
                     urlIsImage: this.urlIsImage
                 },
                 events: {
@@ -1665,6 +1667,7 @@ export default {
                 forced_iframe: updatedValues.urlForcedIframe,
                 forced_iframe_width: updatedValues.urlIframeWidth,
                 forced_iframe_height: updatedValues.urlIframeHeight,
+                forced_iframe_allowfullscreen: updatedValues.urlIframeAllowfullscreen,
                 is_image: updatedValues.urlIsImage
             }
             this.updateItemDocument({
@@ -1691,6 +1694,8 @@ export default {
                         this.urlIframeWidth = item.document_options['forced_iframe_width'];
                     if (item.document_options !== undefined && item.document_options['forced_iframe_height'] !== undefined)
                         this.urlIframeHeight = item.document_options['forced_iframe_height'];
+                    if (item.document_options !== undefined && item.document_options['forced_iframe_allowfullscreen'] !== undefined)
+                        this.urlIframeAllowfullscreen = item.document_options['forced_iframe_allowfullscreen'];
 
                     this.isLoading = false;
 
@@ -1983,6 +1988,8 @@ export default {
                         this.urlIframeWidth = this.form.document_options['forced_iframe_width'];
                     if (this.form.document_options !== undefined && this.form.document_options['forced_iframe_height'] !== undefined)
                         this.urlIframeHeight = this.form.document_options['forced_iframe_height'];
+                    if (this.form.document_options !== undefined && this.form.document_options['forced_iframe_allowfullscreen'] !== undefined)
+                        this.urlIframeAllowfullscreen = this.form.document_options['forced_iframe_allowfullscreen'];
                     
                     /**
                      * Fires action tainacan_item_edition_item_loaded

--- a/src/views/admin/components/metadata-types/url/class-tainacan-url.php
+++ b/src/views/admin/components/metadata-types/url/class-tainacan-url.php
@@ -168,7 +168,8 @@ class URL extends Metadata_Type {
 
 						// Creates an embed with responsive wrapper
 						$tainacan_embed = \Tainacan\Embed::get_instance();
-						$return = $tainacan_embed->add_responsive_wrapper( '<iframe src="' . $value . '" width="100%" height="' . $iframeMininumHeight  . '" style="border:none;" allowfullscreen="' . ($this->get_option('iframe-allowfullscreen') == 'yes' ? 'true' : 'false') . '"></iframe>' );
+						$iframe_allowfullscreen = $this->get_option('iframe-allowfullscreen') == 'yes' ? ' allowfullscreen' : '';
+						$return = $tainacan_embed->add_responsive_wrapper( '<iframe src="' . $value . '" width="100%" height="' . $iframeMininumHeight  . '" style="border:none;"' . $iframe_allowfullscreen . '></iframe>' );
 					}
 
 				// Or we can leave it as a link

--- a/src/views/admin/components/modals/item-document-url-modal.vue
+++ b/src/views/admin/components/modals/item-document-url-modal.vue
@@ -57,6 +57,18 @@
         <b-field
                 v-if="localUrlForcedIframe"
                 :addons="false"
+                :label="$i18n.get('label_document_option_iframe_allowfullscreen')">
+                &nbsp;
+            <b-switch
+                    v-model="localUrlIframeAllowfullscreen" 
+                    size="is-small" />
+            <help-button
+                    :title="$i18n.get('label_document_option_iframe_allowfullscreen')"
+                    :message="$i18n.get('info_document_option_iframe_allowfullscreen')" />
+        </b-field>
+        <b-field
+                v-if="localUrlForcedIframe"
+                :addons="false"
                 :label="$i18n.get('label_document_option_is_image')">
                 &nbsp;
             <b-switch
@@ -94,6 +106,7 @@ export default {
         urlForcedIframe: false,
         urlIframeWidth: 600,
         urlIframeHeight: 450,
+        urlIframeAllowfullscreen: false,
         urlIsImage: false,
     },
     emits: [
@@ -107,6 +120,7 @@ export default {
             localUrlForcedIframe: false,
             localUrlIframeWidth: 600,
             localUrlIframeHeight: 450,
+            localUrlIframeAllowfullscreen: false,
             localUrlIsImage: false,
         }
     },
@@ -115,6 +129,7 @@ export default {
         this.localUrlForcedIframe = this.urlForcedIframe;
         this.localUrlIframeWidth = this.urlIframeWidth;
         this.localUrlIframeHeight = this.urlIframeHeight;
+        this.localUrlIframeAllowfullscreen = this.urlIframeAllowfullscreen;
         this.localUrlIsImage = this.urlIsImage;
         if (
             this.$refs && 
@@ -139,6 +154,7 @@ export default {
                     urlForcedIframe: this.localUrlForcedIframe,
                     urlIframeWidth: this.localUrlIframeWidth,
                     urlIframeHeight: this.localUrlIframeHeight,
+                    urlIframeAllowfullscreen: this.localUrlIframeAllowfullscreen,
                     urlIsImage: this.localUrlIsImage
                 });
         }

--- a/src/views/gutenberg-blocks/blocks/item-submission-form/theme.vue
+++ b/src/views/gutenberg-blocks/blocks/item-submission-form/theme.vue
@@ -144,6 +144,18 @@
                             <b-field
                                     v-if="form.document_options && form.document_options.forced_iframe"
                                     :addons="false"
+                                    :label="$i18n.get('label_document_option_iframe_allowfullscreen')">
+                                    &nbsp;
+                                <b-switch
+                                        v-model="form.document_options.forced_iframe_allowfullscreen"
+                                        size="is-small" />
+                                <help-button
+                                        :title="$i18n.get('label_document_option_iframe_allowfullscreen')"
+                                        :message="$i18n.get('info_document_option_iframe_allowfullscreen')" />
+                            </b-field>
+                            <b-field
+                                    v-if="form.document_options && form.document_options.forced_iframe"
+                                    :addons="false"
                                     :label="$i18n.get('label_document_option_is_image')">
                                     &nbsp;
                                 <b-switch
@@ -860,6 +872,7 @@ export default {
                     forced_iframe: false,
                     forced_iframe_width: 600,
                     forced_iframe_height: 450,
+                    forced_iframe_allowfullscreen: false,
                     is_image: false
                 }
             },

--- a/src/views/tainacan-i18n.php
+++ b/src/views/tainacan-i18n.php
@@ -679,6 +679,7 @@ return apply_filters( 'tainacan-i18n', [
 	'label_amount_of_metadata_of_type'	 			 =>	__( 'Amount of metadata of this type', 'tainacan'),
 	'label_document_option_iframe_height'			 =>	__( 'Iframe height (px)', 'tainacan'),
 	'label_document_option_iframe_width'			 =>	__( 'Iframe width (px)', 'tainacan'),
+	'label_document_option_iframe_allowfullscreen'	 => __( 'Allow fullscreen on forced iframe', 'tainacan' ),
 	'label_document_option_is_image'				 => __( 'Is link to external image', 'tainacan' ),
 	'label_limit_max_values'						 => __( 'Limit the amount of multiple values', 'tainacan'),
 	'label_items_selection'							 => __( 'Items selection', 'tainacan'),
@@ -1149,6 +1150,7 @@ return apply_filters( 'tainacan-i18n', [
 	'info_metadata_autocomplete_suggestions'		 => __( 'Some values already used on this metadatum:', 'tainacan' ),
 	'info_related_items'							 => __( 'These are items that are related to this item via their own relationship type metadata. You can edit such relation on their pages.', 'tainacan'),
 	'info_document_option_forced_iframe'			 => __( 'Attempt to use an iframe to embed url content on the item page. You may use this option if the autoembed does not work.', 'tainacan'),
+	'info_document_option_iframe_allowfullscreen'	 => __( 'If forcing the use of an iframe, allows it to request fullscreen to the browser.', 'tainacan' ),
 	'info_document_option_is_image'					 => __( 'If you are linking directly to an external image, use this option so it can be properly embedded.', 'tainacan' ),
 	/* translators: %s is the number of filters applied */
 	'info_%s_applied_filters'						 => __( '<strong>%s</strong> filters applied', 'tainacan'),


### PR DESCRIPTION
## Description

Adds an **Allow fullscreen on forced iframe** option for URL-type item documents, bringing them in line with the existing URL metadata setting.

When “Render content in iframe” is enabled, editors can opt in to `allowfullscreen` on the forced iframe. The option is available in the item edition URL modal and in the item submission form, exposed via `document_options.forced_iframe_allowfullscreen` in the API, and applied in `get_document_as_html()`.

Also adjusts URL metadata iframe output so `allowfullscreen` is only emitted when enabled. Boolean attributes are presence-based, so `allowfullscreen="false"` would still allow fullscreen; omitting the attribute preserves previous behavior for existing content.

## Related issue

Closes #679

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would change existing behavior)
- [ ] Refactor / technical debt (no user-facing change)
- [ ] Documentation

## Checklist

- [x] My code follows the project's coding standards (ESLint / PHPCS)
- [x] I have tested my changes locally
- [ ] I have added or updated tests when applicable
- [ ] If I changed a Gutenberg block's `block.json` or `save.js`, I updated the corresponding `deprecated.js`
- [ ] I have updated the documentation when needed
- [x] For UI changes, I have added screenshots or a screen recording below

## Screenshots / recordings

<img width="1186" height="793" alt="image" src="https://github.com/user-attachments/assets/0d457ade-7807-4562-a6f5-301bbb066b2e" />
