### PR TITLE
feat: Autocomplete and Taginput filters in Contrl Metadata types.

### DIFF
--- a/src/views/admin/components/filter-types/autocomplete/TainacanFilterAutocomplete.vue
+++ b/src/views/admin/components/filter-types/autocomplete/TainacanFilterAutocomplete.vue
@@ -46,6 +46,7 @@
 </template>
 
 <script>
+    import qs from 'qs';
     import { tainacanApi, isCancel } from '../../../js/axios'
     import { filterTypeMixin, dynamicFilterTypeMixin } from '../../../js/filter-types-mixin';
 
@@ -63,6 +64,12 @@
                 searchOffset: 0,
                 searchNumber: 12,
                 totalFacets: 0
+            }
+        },
+        computed: {
+            usesRelationshipValues() {
+                return this.metadatumType === 'Tainacan\\Metadata_Types\\Relationship' ||
+                    this.metadatumType === 'Tainacan\\Metadata_Types\\Control';
             }
         },
         watch: {
@@ -118,7 +125,7 @@
                     if (this.getOptionsValuesCancel != undefined)
                         this.getOptionsValuesCancel.cancel('Facet search Canceled.');
 
-                    const promise = ( this.metadatumType === 'Tainacan\\Metadata_Types\\Relationship' )
+                    const promise = this.usesRelationshipValues
                         ? this.getValuesRelationship({
                             search: this.searchQuery,
                             isRepositoryLevel: this.isRepositoryLevel,
@@ -180,6 +187,31 @@
                             })
                             .catch(error => {
                                 this.$console.log(error);
+                            });
+                    } else if (this.metadatumType === 'Tainacan\\Metadata_Types\\Control') {
+
+                        let endpoint = `/collection/${this.filter.collection_id}/facets/${this.filter.metadatum.metadatum_id}?getSelected=1&offset=0&number=1&count_items=0`;
+
+                        if (this.isRepositoryLevel)
+                            endpoint = `/facets/${this.filter.metadatum.metadatum_id}?getSelected=1&offset=0&number=1&count_items=0`;
+                        else if (this.filter.collection_id == 'default' && this.currentCollectionId)
+                            endpoint = `/collection/${this.currentCollectionId}/facets/${this.filter.metadatum.metadatum_id}?getSelected=1&offset=0&number=1&count_items=0`;
+
+                        let currentQuery = JSON.parse(JSON.stringify(this.query));
+                        if (currentQuery.fetch_only != undefined)
+                            delete currentQuery.fetch_only;
+
+                        tainacanApi.get(endpoint + '&' + qs.stringify({ 'current_query': currentQuery }))
+                            .then( res => {
+                                const values = res.data.values || res.data;
+                                const match = (Array.isArray(values) ? values : []).find(option => String(option.value) === String(metadata.value));
+                                this.label = match ? match.label : metadata.value;
+                                this.selected = this.label;
+                            })
+                            .catch(error => {
+                                this.$console.log(error);
+                                this.label = metadata.value;
+                                this.selected = metadata.value;
                             });
                     } else {
                         this.label = metadata.value;

--- a/src/views/admin/components/filter-types/autocomplete/class-tainacan-autocomplete.php
+++ b/src/views/admin/components/filter-types/autocomplete/class-tainacan-autocomplete.php
@@ -10,7 +10,7 @@ class Autocomplete extends Filter_Type {
 
     function __construct(){
         $this->set_name( __('Autocomplete', 'tainacan') );
-        $this->set_supported_types(['string','long_string','item']);
+        $this->set_supported_types(['string','long_string','item','control']);
         $this->set_component('tainacan-filter-autocomplete');
         $this->set_use_max_options(false);
         $this->set_preview_template('

--- a/src/views/admin/components/filter-types/taginput/TainacanFilterTaginput.vue
+++ b/src/views/admin/components/filter-types/taginput/TainacanFilterTaginput.vue
@@ -129,7 +129,11 @@
                 if (this.getOptionsValuesCancel != undefined)
                     this.getOptionsValuesCancel.cancel('Facet search Canceled.');
 
-                const promise = ( this.metadatumType === 'Tainacan\\Metadata_Types\\Relationship' || this.metadatumType === 'Tainacan\\Metadata_Types\\User' )
+                const promise = (
+                    this.metadatumType === 'Tainacan\\Metadata_Types\\Relationship' ||
+                    this.metadatumType === 'Tainacan\\Metadata_Types\\User' ||
+                    this.metadatumType === 'Tainacan\\Metadata_Types\\Control'
+                )
                     ? this.getValuesRelationship({
                         search: this.searchQuery,
                         isRepositoryLevel: this.isRepositoryLevel,

--- a/src/views/admin/components/filter-types/taginput/class-tainacan-taginput.php
+++ b/src/views/admin/components/filter-types/taginput/class-tainacan-taginput.php
@@ -10,7 +10,7 @@ class Taginput extends Filter_Type {
 
     function __construct(){
         $this->set_name( __('Tag Input', 'tainacan') );
-        $this->set_supported_types(['string','long_string','item','user']);
+        $this->set_supported_types(['string','long_string','item','user','control']);
         $this->set_component('tainacan-filter-taginput');
         $this->set_use_max_options(false);
         $this->set_preview_template('


### PR DESCRIPTION
## Description

Adds `control` metadata type support to the Autocomplete and Tag Input filter types, so repository-level control metadata (notably Collection ID) can use those filters in addition to Checkbox List.

Previously only Checkbox declared compatibility with the `control` primitive. Autocomplete and Tag Input already handled entity-backed values for Relationship (and User for Tag Input) via the facets/`getValuesRelationship` path; this change extends that path to Control and registers `control` in each filter’s PHP `supported_types`.

For Autocomplete, selected-value display resolves Control labels the same way Relationship resolves item titles: when restoring a filter from the query, it fetches the human-readable label (via facets with `getSelected`) instead of showing the raw ID.

## Related issue

Closes #1081 

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would change existing behavior)
- [ ] Refactor / technical debt (no user-facing change)
- [ ] Documentation

## Checklist

- [x] My code follows the project's coding standards (ESLint / PHPCS)
- [x] I have tested my changes locally
- [ ] I have added or updated tests when applicable
- [ ] If I changed a Gutenberg block's `block.json` or `save.js`, I updated the corresponding `deprecated.js`
- [ ] I have updated the documentation when needed
- [x] For UI changes, I have added screenshots or a screen recording below

## Screenshots / recordings

<img width="542" height="446" alt="image" src="https://github.com/user-attachments/assets/45f253e4-8940-4440-938b-de1936f2c562" />
