### PR TITLE
Fix/sql injection vulnerability on reports

### DIFF
--- a/src/classes/api/endpoints/class-tainacan-rest-reports-controller.php
+++ b/src/classes/api/endpoints/class-tainacan-rest-reports-controller.php
@@ -606,7 +606,17 @@ class REST_Reports_Controller extends REST_Controller {
 				intval($count_posts->publish ?? 0) + intval($count_posts->private ?? 0) + intval($count_posts->pending ?? 0);
 
 		global $wpdb;
-		$string_meta_ids = "'".implode("','", $meta_ids)."'";
+
+		$meta_ids = array_values( array_filter( array_map( 'absint', (array) $meta_ids ) ) );
+		if ( empty( $meta_ids ) ) {
+			return [];
+		}
+
+		$collection_post_type = sanitize_key( $collection_post_type );
+		$meta_placeholders    = implode( ', ', array_fill( 0, count( $meta_ids ), '%d' ) );
+		$params               = array_merge( $meta_ids, [ $collection_post_type ], $meta_ids, [ $collection_post_type ], $meta_ids );
+
+		// phpcs:ignore WordPress.DB.PreparedSQLPlaceholders.ReplacementsWrongNumber, WordPress.DB.PreparedSQL.NotPrepared
 		$sql_statement = $wpdb->prepare(
 			"SELECT p.post_title AS 'name', pp.post_title AS 'parent_name', p.id AS id, IFNULL(((m.total/$total_items) * 100), 0) as fill_percentage
 			FROM
@@ -616,11 +626,11 @@ class REST_Reports_Controller extends REST_Controller {
 				(
 					SELECT meta_key, count(DISTINCT post_id) AS total
 					FROM $wpdb->postmeta 
-					WHERE $wpdb->postmeta.meta_key IN ($string_meta_ids)
+					WHERE $wpdb->postmeta.meta_key IN ($meta_placeholders)
 						AND $wpdb->postmeta.post_id IN ( 
 							SELECT id
 							FROM $wpdb->posts
-							WHERE $wpdb->posts.post_type = '$collection_post_type'
+							WHERE $wpdb->posts.post_type = %s
 						)
 					GROUP BY $wpdb->postmeta.meta_key
 					UNION
@@ -632,17 +642,17 @@ class REST_Reports_Controller extends REST_Controller {
 							FROM $wpdb->postmeta
 							WHERE meta_key='_option_taxonomy_id'
 						) mt ON tt.taxonomy = mt.tax_id
-					WHERE mt.meta_key IN ($string_meta_ids)
+					WHERE mt.meta_key IN ($meta_placeholders)
 						AND tr.object_id IN (
 							SELECT id
 							FROM $wpdb->posts
-							WHERE $wpdb->posts.post_type = '$collection_post_type'
+							WHERE $wpdb->posts.post_type = %s
 						)
 					GROUP BY mt.meta_key
 				) m
 				ON (p.id = m.meta_key)
-				WHERE p.id IN($string_meta_ids)
-			", []
+				WHERE p.id IN($meta_placeholders)",
+			...$params
 		);
 		$res = $wpdb->get_results($sql_statement);
 		//return ['t' => $res, 's' => $sql_statement];
@@ -651,15 +661,30 @@ class REST_Reports_Controller extends REST_Controller {
 
 	private function query_count_used_taxononomies() {
 		global $wpdb;
-		$sql_statement = $wpdb->prepare(
+		$res = intval( $wpdb->get_var( $wpdb->prepare(
 			"SELECT COUNT(DISTINCT($wpdb->postmeta.meta_value))
 			 FROM $wpdb->postmeta
-			 WHERE meta_key = '_option_taxonomy_id'
-			", []
-		);
-
-		$res = intval($wpdb->get_var( $sql_statement ));
+			 WHERE meta_key = %s",
+			'_option_taxonomy_id'
+		) ) );
 		return $res;
+	}
+
+	/**
+	 * Build a parameterized collection_id WHERE fragment for logs table queries.
+	 *
+	 * @param mixed $collection_id Collection ID, the literal 'default', or false for no filter.
+	 * @return array{0: string, 1: array} Tuple of [ $where_sql, $params ].
+	 */
+	private function build_logs_collection_where( $collection_id ) {
+		if ( $collection_id === false ) {
+			return [ '1=1', [] ];
+		}
+
+		return [
+			'collection_id = %s',
+			[ sanitize_text_field( (string) $collection_id ) ],
+		];
 	}
 
 	public function get_activities($request) {
@@ -732,26 +757,29 @@ class REST_Reports_Controller extends REST_Controller {
 			$collection_from = "";
 			if($collection_id !== false) {
 				$collection_from = "INNER JOIN $wpdb->postmeta pm ON p.id = pm.post_id AND (pm.meta_key = %s AND pm.meta_value = %s)";
-				$collection_from = $wpdb->prepare($collection_from, 'collection_id', sanitize_text_field($collection_id));
+				$collection_from = $wpdb->prepare($collection_from, 'collection_id', sanitize_text_field( (string) $collection_id ));
 			}
 			$sql_statement = $wpdb->prepare(
 				"SELECT count(*) as total, DATE(p.post_date) as date
 				FROM $wpdb->posts p $collection_from
-				WHERE p.post_type='tainacan-log' AND p.post_date BETWEEN '$start' AND '$end'
+				WHERE p.post_type='tainacan-log' AND p.post_date BETWEEN %s AND %s
 				GROUP BY DATE(p.post_date)
-				ORDER BY DATE(p.post_date)", []
+				ORDER BY DATE(p.post_date)",
+				$start,
+				$end
 			);
 			return $wpdb->get_results($sql_statement);
 		}
 
 		$tainacan_log_table = Repositories\Logs::get_instance()->get_table_name();
-		$collection_where =  $collection_id == false ? '1=1' : "collection_id=$collection_id";
+		[ $collection_where, $collection_params ] = $this->build_logs_collection_where( $collection_id );
 		$sql_statement = $wpdb->prepare(
 			"SELECT count(*) as total, DATE(p.date) as date
 			FROM $tainacan_log_table p
-			WHERE p.date BETWEEN '$start' AND '$end' AND ($collection_where)
+			WHERE p.date BETWEEN %s AND %s AND ($collection_where)
 			GROUP BY DATE(p.date)
-			ORDER BY DATE(p.date)", []
+			ORDER BY DATE(p.date)",
+			...array_merge( [ $start, $end ], $collection_params )
 		);
 		return $wpdb->get_results($sql_statement);
 	}
@@ -773,24 +801,27 @@ class REST_Reports_Controller extends REST_Controller {
 			$collection_from = "";
 			if($collection_id !== false) {
 				$collection_from = "INNER JOIN $wpdb->postmeta pm ON p.id = pm.post_id AND (pm.meta_key = %s AND pm.meta_value = %s)";
-				$collection_from = $wpdb->prepare($collection_from, 'collection_id', sanitize_text_field($collection_id));
+				$collection_from = $wpdb->prepare($collection_from, 'collection_id', sanitize_text_field( (string) $collection_id ));
 			}
 			$sql_statement = $wpdb->prepare(
 				"SELECT p.post_author  as user_id, count(*) as total, DATE(p.post_date) as date
 				FROM $wpdb->posts p $collection_from
-				WHERE p.post_type='tainacan-log' AND p.post_date BETWEEN '$start' AND '$end'
+				WHERE p.post_type='tainacan-log' AND p.post_date BETWEEN %s AND %s
 				GROUP BY p.post_author, DATE(p.post_date)
-				ORDER BY DATE(p.post_date)", []
+				ORDER BY DATE(p.post_date)",
+				$start,
+				$end
 			);
 		} else {
 			$tainacan_log_table = Repositories\Logs::get_instance()->get_table_name();
-			$collection_where =  $collection_id == false ? '1=1' : "collection_id=$collection_id";
+			[ $collection_where, $collection_params ] = $this->build_logs_collection_where( $collection_id );
 			$sql_statement = $wpdb->prepare(
 				"SELECT p.user_id, count(*) as total, DATE(p.date) as date
 				FROM $tainacan_log_table p
-				WHERE p.date BETWEEN '$start' AND '$end' AND ($collection_where)
+				WHERE p.date BETWEEN %s AND %s AND ($collection_where)
 				GROUP BY p.user_id, DATE(p.date)
-				ORDER BY DATE(p.date)", []
+				ORDER BY DATE(p.date)",
+				...array_merge( [ $start, $end ], $collection_params )
 			);
 		}
 
@@ -833,26 +864,26 @@ class REST_Reports_Controller extends REST_Controller {
 			$collection_from = "";
 			if($collection_id !== false) {
 				$collection_from = "INNER JOIN {$wpdb->postmeta} pm_col ON p.id = pm_col.post_id AND (pm_col.meta_key = %s AND pm_col.meta_value = %s)";
-				$collection_from = $wpdb->prepare($collection_from, 'collection_id', sanitize_text_field($collection_id));
+				$collection_from = $wpdb->prepare($collection_from, 'collection_id', sanitize_text_field( (string) $collection_id ));
 			}
-			$sql_statement = $wpdb->prepare(
+			$sql_statement =
 				"SELECT	count(*) as total, p.post_author as user, pm.meta_value as action
 				FROM $wpdb->posts p 
 				INNER JOIN $wpdb->postmeta pm ON p.id = pm.post_id AND pm.meta_key = 'action'
 				$collection_from
 				WHERE p.post_type='tainacan-log'
 				GROUP BY p.post_author, pm.meta_value 
-				ORDER BY total DESC", []
-			);
+				ORDER BY total DESC";
 		} else {
 			$tainacan_log_table = Repositories\Logs::get_instance()->get_table_name();
-			$collection_where =  $collection_id == false ? '1=1' : "collection_id=$collection_id";
+			[ $collection_where, $collection_params ] = $this->build_logs_collection_where( $collection_id );
 			$sql_statement = $wpdb->prepare(
 				"SELECT	count(*) as total, p.user_id as user, p.action as action
 				FROM $tainacan_log_table p
 				WHERE $collection_where
 				GROUP BY p.user_id, p.action
-				ORDER BY total DESC", []
+				ORDER BY total DESC",
+				...$collection_params
 			);
 		}
 		

--- a/src/classes/repositories/class-tainacan-items.php
+++ b/src/classes/repositories/class-tainacan-items.php
@@ -24,6 +24,13 @@ class Items extends Repository {
 	// temporary variable used to filter items query
 	private $fetching_from_collections = [];
 
+	/**
+	 * Temporary state for the optional relationship metaquery posts_where filter.
+	 *
+	 * @var array{meta_id?: string, search_meta_id?: string, search_meta_value?: string}
+	 */
+	private $relationsip_metaquery = [];
+
 	protected function init() {
 		add_filter( 'comments_open', [$this, 'hook_comments_open'], 10, 2);
 		add_action( 'tainacan-api-item-updated', array( &$this, 'hook_api_updated_item' ), 10, 2 );
@@ -896,23 +903,34 @@ class Items extends Repository {
 	}
 
 	private function parse_relationship_metaquery ($args) {
-		if( isset($args['meta_query']) ) {
+		if ( isset($args['meta_query']) ) {
 			$Tainacan_Metadata = \Tainacan\Repositories\Metadata::get_instance();
 			foreach($args['meta_query'] as $idx => $meta) {
+				if ( ! is_array( $meta ) || ! isset( $meta['key'] ) || $meta['key'] === '' ) {
+					continue;
+				}
 				$meta_id = $meta['key'];
 				$metadata = $Tainacan_Metadata->fetch($meta_id);
-				if(
+				if (
 					isset($metadata) &&
 					$metadata instanceof \Tainacan\Entities\Metadatum &&
 					$metadata->get_metadata_type() === 'Tainacan\\Metadata_Types\\Relationship' &&
 					(isset($meta['compare']) && !in_array($meta['compare'], ['IN', 'NOT IN', '=']))
 				) {
 					$options  = $metadata->get_metadata_type_options();
-					if( isset($options) && isset($options['search']) ) {
+					if ( isset($options) && isset($options['search']) ) {
+						$search_meta_value = $args['meta_query'][$idx]['value'] ?? '';
+						// metaquery value may be a string or an array. This SQL path only
+						// supports one LIKE term, so take the first value for now.
+						// How to handle multiple values (OR vs AND vs a single phrase)
+						// is still an open decision.
+						if ( is_array( $search_meta_value ) ) {
+							$search_meta_value = reset( $search_meta_value );
+						}
 						$this->relationsip_metaquery = array(
-							'meta_id' => $meta_id,
-							'search_meta_id' => $options['search'],
-							'search_meta_value' => $args['meta_query'][$idx]['value']
+							'meta_id' => (string) $meta_id,
+							'search_meta_id' => (string) $options['search'],
+							'search_meta_value' => (string) $search_meta_value,
 						);
 						$args['meta_query'][$idx]['compare'] = '!=';
 						$args['meta_query'][$idx]['value'] = '';
@@ -926,11 +944,21 @@ class Items extends Repository {
 	}
 
 	function posts_where_relationship_metaquery( $where ) {
-		$meta_id = $this->relationsip_metaquery['meta_id'];
-		$search_meta_id = $this->relationsip_metaquery['search_meta_id'];
-		$search_meta_value = $this->relationsip_metaquery['search_meta_value'];
-		$SQL_related_item = " SELECT DISTINCT post_id FROM wp_postmeta WHERE meta_key=$search_meta_id AND meta_value LIKE '%$search_meta_value%'";
-		$where .= " AND (wp_postmeta.meta_key = '$meta_id' AND wp_postmeta.meta_value IN ( $SQL_related_item ) ) ";
+		global $wpdb;
+
+		$meta_id = $this->relationsip_metaquery['meta_id'] ?? '';
+		$search_meta_id = $this->relationsip_metaquery['search_meta_id'] ?? '';
+		$search_meta_value = $this->relationsip_metaquery['search_meta_value'] ?? '';
+		$like = '%' . $wpdb->esc_like( $search_meta_value ) . '%';
+
+		$where .= $wpdb->prepare(
+			" AND ({$wpdb->postmeta}.meta_key = %s AND {$wpdb->postmeta}.meta_value IN (
+				SELECT DISTINCT post_id FROM {$wpdb->postmeta} WHERE meta_key = %s AND meta_value LIKE %s
+			) ) ",
+			$meta_id,
+			$search_meta_id,
+			$like
+		);
 		remove_filter( 'posts_where', array($this, 'posts_where_relationship_metaquery') );
 		return $where;
 	}

--- a/src/views/admin/components/reports/activities-block.vue
+++ b/src/views/admin/components/reports/activities-block.vue
@@ -160,8 +160,6 @@ export default {
                     name: this.$i18n.get('activities'),
                     data: []
                 }];
-            else
-                this.chartSeries = [];
 
             let maximumOfActivitiesInADay = 0;
             let everyDay = this.getDaysArray(this.currentStart, this.currentEnd);


### PR DESCRIPTION
## Description

Hardens raw SQL in `REST_Reports_Controller` against SQL injection by binding dynamic values through `$wpdb->prepare()` instead of string interpolation.

Previously, activity report queries built clauses like `collection_id=$collection_id` and `BETWEEN '$start' AND '$end'` with a no-op `prepare(..., [])`. Metadata distribution queries also interpolated meta IDs and `post_type` into `IN (...)` / equality clauses.

Changes:
- Bind `collection_id` with `%s` so numeric IDs and the literal `'default'` are both supported safely (via `build_logs_collection_where()`)
- Bind date range values with `%s` in both the new logs table and deprecated logs code paths
- Sanitize and bind meta IDs (`%d`) and collection post type (`%s`) in `query_item_metadata_distribution()`
- Parameterize the static meta key in `query_count_used_taxononomies()` so PHPCS stays ok, even though it is not really required there
- There is also a small fix on the frontend for when the Reports are loaded empty in the Vue.js component.

Exploitability via the current REST routes was partially limited by `[\d]+` path constraints and auth checks; this is defense-in-depth and aligns the reports controller with the safer pattern already used in the Logs repository.

## Related issue

This is a response to a Patchstack vulnerability report opened yesterday. The report will be public in August 16.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would change existing behavior)
- [x] Refactor / technical debt (no user-facing change)
- [ ] Documentation

## Checklist

- [x] My code follows the project's coding standards (ESLint / PHPCS)
- [x] I have tested my changes locally
- [ ] I have added or updated tests when applicable
- [ ] If I changed a Gutenberg block's `block.json` or `save.js`, I updated the corresponding `deprecated.js`
- [ ] I have updated the documentation when needed
- [ ] For UI changes, I have added screenshots or a screen recording below