### PR TITLE
feat: Adds logic in the Control metadata to build textual search in labels

### DIFF
--- a/src/classes/repositories/class-tainacan-metadata.php
+++ b/src/classes/repositories/class-tainacan-metadata.php
@@ -1286,6 +1286,9 @@ class Metadata extends Repository {
 				$search_q = $wpdb->prepare("AND t.name LIKE %s", '%' . $search . '%');
 			} elseif ( $metadatum_type === 'Tainacan\Metadata_Types\User' ) {
 				$search_q = $wpdb->prepare("AND meta_value IN ( SELECT ID FROM $wpdb->users WHERE display_name LIKE %s )", '%' . $search . '%');
+			} elseif ( $metadatum_type === 'Tainacan\Metadata_Types\Control' ) {
+				$metadata_type_object = $metadatum->get_metadata_type_object();
+				$search_q = $metadata_type_object->get_control_metadatum_search_sql( $search );
 			} else {
 				$search_q = $wpdb->prepare("AND meta_value LIKE %s", '%' . $search . '%');
 			}

--- a/src/views/admin/components/metadata-types/control/class-tainacan-control.php
+++ b/src/views/admin/components/metadata-types/control/class-tainacan-control.php
@@ -149,6 +149,7 @@ class Control extends Metadata_Type {
 		$control_metadatum = $this->get_option( 'control_metadatum' );
 		$like_search = '%' . $wpdb->esc_like( $search ) . '%';
 		$search_q = '';
+		$stripos = function_exists( 'mb_stripos' ) ? 'mb_stripos' : 'stripos';
 
 		switch ( $control_metadatum ) {
 			case 'collection_id':
@@ -164,7 +165,7 @@ class Control extends Metadata_Type {
 				$matching_values = [];
 				foreach ( [ 'yes', 'no' ] as $value ) {
 					$label = $this->get_control_metadatum_value( $value, 'has_thumbnail', 'string' );
-					if ( stripos( (string) $label, $search ) !== false || stripos( $value, $search ) !== false ) {
+					if ( $stripos( (string) $label, $search ) !== false || $stripos( $value, $search ) !== false ) {
 						$matching_values[] = $value;
 					}
 				}
@@ -184,7 +185,7 @@ class Control extends Metadata_Type {
 				$known_values = [ 'attachment', 'text', 'url', 'empty', 'application/pdf' ];
 				foreach ( $known_values as $value ) {
 					$label = $this->get_document_as_string( $value );
-					if ( stripos( (string) $label, $search ) !== false || stripos( $value, $search ) !== false ) {
+					if ( $stripos( (string) $label, $search ) !== false || $stripos( $value, $search ) !== false ) {
 						$matching_values[] = $value;
 					}
 				}
@@ -207,18 +208,14 @@ class Control extends Metadata_Type {
 				];
 				foreach ( $mime_prefixes as $prefix => $label ) {
 					// Match category alone (e.g. "Imagem" or "image").
-					if ( stripos( $label, $search ) !== false || stripos( $prefix, $search ) !== false ) {
+					if ( $stripos( $label, $search ) !== false || $stripos( $prefix, $search ) !== false ) {
 						// $prefix is a hardcoded key from $mime_prefixes.
 						$clauses[] = $wpdb->prepare( 'meta_value LIKE %s', $wpdb->esc_like( $prefix ) . '/%' );
 					}
 
 					// Match full translated labels (e.g. "Imagem/jpeg" → image/jpeg).
 					$translated_prefix = $label . '/';
-					$starts_with_translated = function_exists( 'mb_stripos' )
-						? mb_stripos( $search, $translated_prefix ) === 0
-						: stripos( $search, $translated_prefix ) === 0;
-
-					if ( $starts_with_translated ) {
+					if ( $stripos( $search, $translated_prefix ) === 0 ) {
 						$subtype = function_exists( 'mb_substr' )
 							? mb_substr( $search, mb_strlen( $translated_prefix ) )
 							: substr( $search, strlen( $translated_prefix ) );

--- a/src/views/admin/components/metadata-types/control/class-tainacan-control.php
+++ b/src/views/admin/components/metadata-types/control/class-tainacan-control.php
@@ -132,6 +132,129 @@ class Control extends Metadata_Type {
 	}
 
 	/**
+	 * Build the SQL fragment used by Metadata::fetch_all_metadatum_values() to filter
+	 * control metadata facet values by a textual search against their labels.
+	 *
+	 * @param string $search The search string.
+	 * @return string SQL fragment starting with "AND ..."
+	 */
+	public function get_control_metadatum_search_sql( $search ) {
+		global $wpdb;
+
+		$search = trim( (string) $search );
+		if ( $search === '' ) {
+			return '';
+		}
+
+		$control_metadatum = $this->get_option( 'control_metadatum' );
+		$like_search = '%' . $wpdb->esc_like( $search ) . '%';
+		$search_q = '';
+
+		switch ( $control_metadatum ) {
+			case 'collection_id':
+				$post_type = \Tainacan\Entities\Collection::get_post_type();
+				$search_q = $wpdb->prepare(
+					"AND meta_value IN ( SELECT ID FROM $wpdb->posts WHERE post_type = %s AND post_title LIKE %s )",
+					$post_type,
+					$like_search
+				);
+			break;
+
+			case 'has_thumbnail':
+				$matching_values = [];
+				foreach ( [ 'yes', 'no' ] as $value ) {
+					$label = $this->get_control_metadatum_value( $value, 'has_thumbnail', 'string' );
+					if ( stripos( (string) $label, $search ) !== false || stripos( $value, $search ) !== false ) {
+						$matching_values[] = $value;
+					}
+				}
+				if ( empty( $matching_values ) ) {
+					$search_q = 'AND 1=0';
+				} else {
+					// Values come from the fixed yes/no set above; still prepare them.
+					$in_list = implode( ',', array_map( function( $value ) use ( $wpdb ) {
+						return $wpdb->prepare( '%s', $value );
+					}, $matching_values ) );
+					$search_q = "AND meta_value IN ($in_list)";
+				}
+			break;
+
+			case 'document_type':
+				$matching_values = [];
+				$known_values = [ 'attachment', 'text', 'url', 'empty', 'application/pdf' ];
+				foreach ( $known_values as $value ) {
+					$label = $this->get_document_as_string( $value );
+					if ( stripos( (string) $label, $search ) !== false || stripos( $value, $search ) !== false ) {
+						$matching_values[] = $value;
+					}
+				}
+
+				$clauses = [];
+				if ( ! empty( $matching_values ) ) {
+					// Values come from the fixed known_values set above; still prepare them.
+					$in_list = implode( ',', array_map( function( $value ) use ( $wpdb ) {
+						return $wpdb->prepare( '%s', $value );
+					}, $matching_values ) );
+					$clauses[] = "meta_value IN ($in_list)";
+				}
+
+				$mime_prefixes = [
+					'image'       => __( 'Image', 'tainacan' ),
+					'video'       => __( 'Video', 'tainacan' ),
+					'audio'       => __( 'Audio', 'tainacan' ),
+					'text'        => __( 'Text', 'tainacan' ),
+					'application' => __( 'Others', 'tainacan' ),
+				];
+				foreach ( $mime_prefixes as $prefix => $label ) {
+					// Match category alone (e.g. "Imagem" or "image").
+					if ( stripos( $label, $search ) !== false || stripos( $prefix, $search ) !== false ) {
+						// $prefix is a hardcoded key from $mime_prefixes.
+						$clauses[] = $wpdb->prepare( 'meta_value LIKE %s', $wpdb->esc_like( $prefix ) . '/%' );
+					}
+
+					// Match full translated labels (e.g. "Imagem/jpeg" → image/jpeg).
+					$translated_prefix = $label . '/';
+					$starts_with_translated = function_exists( 'mb_stripos' )
+						? mb_stripos( $search, $translated_prefix ) === 0
+						: stripos( $search, $translated_prefix ) === 0;
+
+					if ( $starts_with_translated ) {
+						$subtype = function_exists( 'mb_substr' )
+							? mb_substr( $search, mb_strlen( $translated_prefix ) )
+							: substr( $search, strlen( $translated_prefix ) );
+						$clauses[] = $wpdb->prepare(
+							'meta_value LIKE %s',
+							$wpdb->esc_like( $prefix ) . '/' . $wpdb->esc_like( $subtype ) . '%'
+						);
+					}
+				}
+
+				// Also match raw stored values (e.g. "image/jpeg", "jpeg").
+				$clauses[] = $wpdb->prepare( 'meta_value LIKE %s', $like_search );
+
+				$search_q = 'AND (' . implode( ' OR ', $clauses ) . ')';
+			break;
+
+			default:
+				$search_q = $wpdb->prepare( 'AND meta_value LIKE %s', $like_search );
+			break;
+		}
+
+		/**
+		 * Filter the SQL fragment used to search control metadata facet values by label.
+		 *
+		 * Useful for plugins that register custom control_metadatum kinds.
+		 * Callbacks must return a fully prepared/escaped SQL fragment.
+		 *
+		 * @param string $search_q           SQL fragment starting with "AND ..."
+		 * @param string $search             The search string.
+		 * @param string $control_metadatum  The control_metadatum option.
+		 * @param \Tainacan\Metadata_Types\Control $metadata_type The Control metadata type instance.
+		 */
+		return apply_filters( 'tainacan-control-metadatum-search-sql', $search_q, $search, $control_metadatum, $this );
+	}
+
+	/**
 	 * Return the value of an Item_Metadata_Entity using a metadatum of this metadatum type as an html string
 	 * 
 	 * @param Item_Metadata_Entity $item_metadata 


### PR DESCRIPTION
## Description

Makes the facets endpoint searchable by Control metadata **labels**, not only raw stored values (e.g. collection IDs or MIME codes).

In `Metadata::fetch_all_metadatum_values()`, adds a Control branch in the search SQL handling that delegates to a new `Control::get_control_metadatum_search_sql()` method:

- **collection_id** — search collection titles via a post subquery (same idea as Relationship)
- **has_thumbnail** — match translated yes/no labels
- **document_type** — match discrete labels, MIME categories, translated forms (e.g. `Imagem/jpeg` → `image/jpeg`), and raw MIME values
- **default** — fall back to `meta_value LIKE`

Query fragments use `$wpdb->prepare()` and `$wpdb->esc_like()`. A `tainacan-control-metadatum-search-sql` filter allows plugins with custom control kinds to override the SQL.

## Related issue

Closes #1088

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would change existing behavior)
- [ ] Refactor / technical debt (no user-facing change)
- [ ] Documentation

## Checklist

- [x] My code follows the project's coding standards (ESLint / PHPCS)
- [x] I have tested my changes locally
- [ ] I have added or updated tests when applicable
- [ ] If I changed a Gutenberg block's `block.json` or `save.js`, I updated the corresponding `deprecated.js`
- [ ] I have updated the documentation when needed
- [ ] For UI changes, I have added screenshots or a screen recording below