### PR TITLE
Fix/1094 single valued empty taxonomy inputs are always sending values

### DIFF
--- a/src/views/admin/components/metadata-types/tainacan-form-item.vue
+++ b/src/views/admin/components/metadata-types/tainacan-form-item.vue
@@ -344,7 +344,7 @@
                     return;
 
                 if ( this.itemMetadatum.value !== null && this.itemMetadatum.value !== false ) {
-
+                    
                     // This routine avoids calling the API if the value did not changed
                     switch(this.itemMetadatum.value.constructor.name) {
 
@@ -377,7 +377,7 @@
                                 if (this.itemMetadatum.value == currentValues)
                                     return;
                             }
-
+                            console.log('currentValues', currentValues);
                             break;
                         }
                         
@@ -403,6 +403,16 @@
                             )
                                 return;
                     }
+                    
+                // If the value is null or false, don't update unless the user actually set something
+                // Sometimes when the page is loaded the itemMetadatum.value is null or false from the API, but the user has not set anything yet.
+                } else {
+                    // Stored value on this.values is empty: don't update unless the user actually set something
+                    const isLocalEmpty =
+                        !this.values ||
+                        (Array.isArray(this.values) && this.values.filter(v => v !== false && v !== null && v !== undefined && v !== '').length === 0);
+                    if (isLocalEmpty)
+                        return;
                 }
                 
                 // If none is the case, the value is update request is sent to the API

--- a/src/views/admin/components/metadata-types/tainacan-form-item.vue
+++ b/src/views/admin/components/metadata-types/tainacan-form-item.vue
@@ -377,7 +377,7 @@
                                 if (this.itemMetadatum.value == currentValues)
                                     return;
                             }
-                            console.log('currentValues', currentValues);
+
                             break;
                         }
                         
@@ -403,7 +403,7 @@
                             )
                                 return;
                     }
-                    
+
                 // If the value is null or false, don't update unless the user actually set something
                 // Sometimes when the page is loaded the itemMetadatum.value is null or false from the API, but the user has not set anything yet.
                 } else {


### PR DESCRIPTION
## Description

Prevents empty single-valued Taxonomy metadata from triggering an item metadata update when the item editing page loads.

Empty single-valued taxonomy values can arrive from the API as `null`/`false`. On mount, `TainacanTaxonomy` hydrates and emits `update:value`, and `performValueChange()` previously skipped the “unchanged” check for those empty stored values, so it always sent an update.

This change treats empty stored + empty local as a no-op, while still allowing real user actions (set/clear) to update.

## Related issue

Closes #1094

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would change existing behavior)
- [ ] Refactor / technical debt (no user-facing change)
- [ ] Documentation

## Checklist

- [x] My code follows the project's coding standards (ESLint / PHPCS)
- [x] I have tested my changes locally
- [ ] I have added or updated tests when applicable
- [ ] If I changed a Gutenberg block's `block.json` or `save.js`, I updated the corresponding `deprecated.js`
- [ ] I have updated the documentation when needed
- [ ] For UI changes, I have added screenshots or a screen recording below

## Screenshots / recordings

N/A — behavior change is in network requests on item edit load (no visual UI change).