### PR TITLE
feat: Implement manage_multiple_input in metadata types

### DIFF
--- a/src/views/admin/components/metadata-types/compound/class-tainacan-compound.php
+++ b/src/views/admin/components/metadata-types/compound/class-tainacan-compound.php
@@ -18,6 +18,7 @@ class Compound extends Metadata_Type {
 		$this->set_name( __('Compound', 'tainacan') );
 		$this->set_description( __('A compound metadatum can have groups of values of different types.', 'tainacan') );
 		$this->set_sortable( false );
+		$this->set_manage_multiple_input( true );
 		$this->set_primitive_type('compound');
 		$this->set_component('tainacan-compound');
 		$this->set_form_component('tainacan-form-compound');

--- a/src/views/admin/components/metadata-types/geocoordinate/class-tainacan-geocoordinate.php
+++ b/src/views/admin/components/metadata-types/geocoordinate/class-tainacan-geocoordinate.php
@@ -22,6 +22,7 @@ class GeoCoordinate extends Metadata_Type {
 		$this->set_name( __('GeoCoordinate', 'tainacan') );
 		$this->set_description( __('Represents a geographical location that is determined by latitude and longitude coordinates.', 'tainacan') );
 		$this->set_sortable( false );
+		$this->set_manage_multiple_input( true );
 		$this->set_default_options([
 			'map_provider' => 'https://tile.openstreetmap.org/{z}/{x}/{y}.png',
 			'attribution' => '&copy; <a target="_blank" href="http://osm.org/copyright">OpenStreetMap</a> contributors',

--- a/src/views/admin/components/metadata-types/metadata-type/class-tainacan-metadata-type.php
+++ b/src/views/admin/components/metadata-types/metadata-type/class-tainacan-metadata-type.php
@@ -95,6 +95,17 @@ abstract class Metadata_Type  {
      */
     private $sortable = true;
 
+    /**
+     * Whether the item form Vue component manages multivalue UI itself.
+     *
+     * When false (default), TainacanFormItem renders N child inputs with add/remove controls
+     * and passes a scalar value per instance. When true, the child receives the full values
+     * array and owns multiplicity.
+     *
+     * @var bool
+     */
+    private $manage_multiple_input = false;
+
     public function __construct(){
         
     }
@@ -283,6 +294,14 @@ abstract class Metadata_Type  {
     public function set_sortable($sortable){
         $this->sortable = $sortable;
     }
+
+    public function get_manage_multiple_input() {
+        return (bool) $this->manage_multiple_input;
+    }
+
+    public function set_manage_multiple_input( $manage_multiple_input ) {
+        $this->manage_multiple_input = (bool) $manage_multiple_input;
+    }
 	
 	/**
 	* Gets a slug based on the class name to represent the metadata type
@@ -306,7 +325,8 @@ abstract class Metadata_Type  {
         $attributes['primitive_type']      = $this->get_primitive_type();
         $attributes['form_component']      = $this->get_form_component();
         $attributes['preview_template']    = $this->get_preview_template();
-        $attributes['sortable']      = $this->get_sortable();
+        $attributes['sortable']            = $this->get_sortable();
+        $attributes['manage_multiple_input'] = $this->get_manage_multiple_input();
         
         return $attributes;
         

--- a/src/views/admin/components/metadata-types/relationship/class-tainacan-relationship.php
+++ b/src/views/admin/components/metadata-types/relationship/class-tainacan-relationship.php
@@ -19,6 +19,7 @@ class Relationship extends Metadata_Type {
 		$this->set_name( __('Relationship', 'tainacan') );
 		$this->set_description( __('A relationship with another item', 'tainacan') );
 		$this->set_sortable( false );
+		$this->set_manage_multiple_input( true );
 		$this->set_preview_template('
 			<div>
 				<div class="taginput control is-expanded has-selected">

--- a/src/views/admin/components/metadata-types/selectbox/class-tainacan-selectbox.php
+++ b/src/views/admin/components/metadata-types/selectbox/class-tainacan-selectbox.php
@@ -34,6 +34,22 @@ class Selectbox extends Metadata_Type {
     }
 
     /**
+     * Checkbox-style inputs manage multiple values in a single control.
+     *
+     * @return bool
+     */
+    public function get_manage_multiple_input() {
+        return in_array(
+            $this->get_option( 'input_type' ),
+            [
+                'tainacan-selectbox-checkbox',
+                'tainacan-selectbox-checkbox-button',
+            ],
+            true
+        );
+    }
+
+    /**
      * @inheritdoc
      */
     public function get_form_labels(){

--- a/src/views/admin/components/metadata-types/tainacan-form-item.vue
+++ b/src/views/admin/components/metadata-types/tainacan-form-item.vue
@@ -61,7 +61,7 @@
         <transition name="filter-item">
             <div   
                     v-show="hideCollapses || isCollapsed || !!errorMessage"
-                    v-if="isTextInputComponent">
+                    v-if="!manageMultipleInput">
                 <p
                         v-if="itemMetadatum.metadatum &&
                             itemMetadatum.metadatum.description &&
@@ -158,7 +158,7 @@
                 </template>
             </div>
 
-            <!-- Non-textual metadata such as taxonomy, relationship, geocoordinate and compound manage multiple state in different ways -->
+            <!-- Metadata types with manage_multiple_input (taxonomy, relationship, etc.) manage multiple state themselves -->
             <div 
                     v-show="hideCollapses || isCollapsed"
                     v-else>
@@ -256,25 +256,13 @@
                     this.itemMetadatum.metadatum.cardinality > 1
                 ) ? this.itemMetadatum.metadatum.cardinality : undefined;
             },
-            isTextInputComponent() {
-                const array = ['tainacan-relationship','tainacan-taxonomy', 'tainacan-compound', 'tainacan-user', 'tainacan-geocoordinate'];
-                if ( array.indexOf(this.metadatumComponent) >= 0 )
-                    return false;
-
-                // Selectbox checkbox inputs manage multiple values in a single control, like taxonomy
-                if (
-                    this.metadatumComponent === 'tainacan-selectbox' &&
+            manageMultipleInput() {
+                return !!(
                     this.itemMetadatum &&
                     this.itemMetadatum.metadatum &&
-                    this.itemMetadatum.metadatum.metadata_type_options &&
-                    (
-                        this.itemMetadatum.metadatum.metadata_type_options.input_type === 'tainacan-selectbox-checkbox' ||
-                        this.itemMetadatum.metadatum.metadata_type_options.input_type === 'tainacan-selectbox-checkbox-button'
-                    )
-                )
-                    return false;
-
-                return true;
+                    this.itemMetadatum.metadatum.metadata_type_object &&
+                    this.itemMetadatum.metadatum.metadata_type_object.manage_multiple_input
+                );
             },
             metadatumFormClasses() {
                 return '' + 

--- a/src/views/admin/components/metadata-types/taxonomy/class-tainacan-taxonomy.php
+++ b/src/views/admin/components/metadata-types/taxonomy/class-tainacan-taxonomy.php
@@ -33,6 +33,7 @@ class Taxonomy extends Metadata_Type {
 		$this->set_name( __('Taxonomy', 'tainacan') );
 		$this->set_description( __('A metadatum to use a taxonomy in this collection', 'tainacan') );
 		$this->set_sortable( false );
+		$this->set_manage_multiple_input( true );
 		$this->set_preview_template('
 			<div>
 				<div>

--- a/src/views/admin/components/metadata-types/user/class-tainacan-user.php
+++ b/src/views/admin/components/metadata-types/user/class-tainacan-user.php
@@ -24,6 +24,7 @@ class User extends Metadata_Type {
 			'default_author' => 'no'
 		]);
 		$this->set_sortable( false );
+		$this->set_manage_multiple_input( true );
 		$this->set_preview_template('
 			<div class="taginput control is-expanded has-selected">
 				<div class="taginput-container is-small is-focusable">


### PR DESCRIPTION
## Description

Adds a `manage_multiple_input` capability on `Metadata_Type` so `TainacanFormItem` can decide whether the parent owns multivalue UI (N inputs + add/remove) or the child receives the full values array.

Previously this lived in a misnamed Vue computed with a hardcoded component denylist and a Selectbox special case. The flag is exposed on `metadata_type_object` via `_toArray()`. Self-managing core types set it to `true`; Selectbox derives it from `input_type` (checkbox modes → `true`). Custom metadata types can opt in with `set_manage_multiple_input( true )`.

## Related issue

Closes #1097

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would change existing behavior)
- [x] Refactor / technical debt (no user-facing change)
- [ ] Documentation

## Checklist

- [x] My code follows the project's coding standards (ESLint / PHPCS)
- [ ] I have tested my changes locally
- [ ] I have added or updated tests when applicable
- [ ] If I changed a Gutenberg block's `block.json` or `save.js`, I updated the corresponding `deprecated.js`
- [ ] I have updated the documentation when needed
- [ ] For UI changes, I have added screenshots or a screen recording below

## Screenshots / recordings

N/A — no visual design changes; behavior should match the previous denylist for core types.