### PR TITLE
fix: Skips BOM encoding characters when reading CSV files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,6 +32,7 @@ src/assets/report.html
 report.txt
 .tmp
 demosaved.csv
+demosaved_bom.csv
 .DS_Store
 src/.DS_Store
 tests/wordpress-test

--- a/src/classes/background-process/importer/class-tainacan-csv.php
+++ b/src/classes/background-process/importer/class-tainacan-csv.php
@@ -23,6 +23,33 @@ class CSV extends Importer {
 	}
 
 	/**
+	 * Opens the temporary CSV file for reading, skipping a UTF-8 BOM when present.
+	 *
+	 * Excel and other tools often save UTF-8 CSV files with a leading BOM (EF BB BF),
+	 * which would otherwise become part of the first column name and break exact
+	 * matches such as special_item_id.
+	 *
+	 * @return resource|false File handle positioned after the BOM, or false on failure.
+	 */
+	protected function open_tmp_file() {
+		if ( ! isset( $this->tmp_file ) || ! file_exists( $this->tmp_file ) ) {
+			return false;
+		}
+
+		$handle = fopen( $this->tmp_file, 'r' );
+		if ( $handle === false ) {
+			return false;
+		}
+
+		$bom = fread( $handle, 3 );
+		if ( $bom !== "\xEF\xBB\xBF" ) {
+			rewind( $handle );
+		}
+
+		return $handle;
+	}
+
+	/**
 	 * alter the default options
 	 */
 	public function set_option($key,$value) {
@@ -33,7 +60,7 @@ class CSV extends Importer {
 	 * @inheritdoc
 	 */
 	public function get_source_metadata() {
-		if (($handle = fopen($this->tmp_file, "r")) !== false) {
+		if (($handle = $this->open_tmp_file()) !== false) {
 			if ( $this->get_option('enclosure') && strlen($this->get_option('enclosure')) > 0 ) {
 				$rawColumns = $this->handle_enclosure( $handle );
 			} else {
@@ -90,14 +117,14 @@ class CSV extends Importer {
 	}
 
 	public function get_source_file_name() {
-		if (isset($this->tmp_file) && file_exists($this->tmp_file) && ($handle = fopen($this->tmp_file, "r")) !== false) {
-			return basename($this->tmp_file);
+		if ( isset( $this->tmp_file ) && file_exists( $this->tmp_file ) ) {
+			return basename( $this->tmp_file );
 		}
 		return false;
 	}
 
 	public function get_source_special_fields() {
-		if (($handle = fopen($this->tmp_file, "r")) !== false) {
+		if (($handle = $this->open_tmp_file()) !== false) {
 			if ( $this->get_option('enclosure') && strlen($this->get_option('enclosure')) > 0 ) {
 				$rawColumns = $this->handle_enclosure( $handle );
 			} else {
@@ -131,7 +158,7 @@ class CSV extends Importer {
 	 * returns all header including special
 	 */
 	public function raw_source_metadata() {
-		if (($handle = fopen($this->tmp_file, "r")) !== false) {
+		if (($handle = $this->open_tmp_file()) !== false) {
 			if ( $this->get_option('enclosure') && strlen($this->get_option('enclosure')) > 0 ){
 				return $this->handle_enclosure( $handle );
 			} else {
@@ -162,7 +189,7 @@ class CSV extends Importer {
 		$this->add_log( 'Processing item on line ' . $item_line );
 		$this->add_log( 'Target collection: ' . $collection_definition['id'] );
 
-		if (($handle = fopen($this->tmp_file, "r")) !== false) {
+		if (($handle = $this->open_tmp_file()) !== false) {
 			$file = $handle;
 		} else {
 			$this->add_error_log(' Error reading the file ');
@@ -281,7 +308,7 @@ class CSV extends Importer {
 			 !empty( $column_item_slug ) || !empty( $column_item_author_id )
 			){
 
-			if (($handle = fopen($this->tmp_file, "r")) !== false) {
+			if (($handle = $this->open_tmp_file()) !== false) {
 				$file = $handle;
 			} else {
 				$this->add_error_log(' Error reading the file ');
@@ -331,7 +358,7 @@ class CSV extends Importer {
 	 * @inheritdoc
 	 */
 	public function get_source_number_of_items() {
-		if ( isset($this->tmp_file) && file_exists($this->tmp_file) && ($handle = fopen($this->tmp_file, "r")) !== false) {
+		if ( ($handle = $this->open_tmp_file()) !== false ) {
 			$cont = 0;
 			while ( ($data = fgetcsv($handle, 0, $this->get_option('delimiter')) ) !== false ) {
 				$cont++;

--- a/src/classes/background-process/importer/class-tainacan-term-importer.php
+++ b/src/classes/background-process/importer/class-tainacan-term-importer.php
@@ -39,6 +39,29 @@ class Term_Importer extends Importer {
 		]);
 	}
 
+	/**
+	 * Opens the temporary CSV file for reading, skipping a UTF-8 BOM when present.
+	 *
+	 * @return resource|false File handle positioned after the BOM, or false on failure.
+	 */
+	protected function open_tmp_file() {
+		if ( ! isset( $this->tmp_file ) || ! file_exists( $this->tmp_file ) ) {
+			return false;
+		}
+
+		$handle = fopen( $this->tmp_file, 'r' );
+		if ( $handle === false ) {
+			return false;
+		}
+
+		$bom = fread( $handle, 3 );
+		if ( $bom !== "\xEF\xBB\xBF" ) {
+			rewind( $handle );
+		}
+
+		return $handle;
+	}
+
 	public function options_form() {
 		ob_start();
 		?>
@@ -132,7 +155,7 @@ class Term_Importer extends Importer {
 
 	public function create_terms( ) {
 
-		if (($handle = fopen($this->tmp_file, "r")) !== false) {
+		if (($handle = $this->open_tmp_file()) !== false) {
 			$file = $handle;
 			$this->set_current_step_total( filesize($this->tmp_file) );
 		} else {
@@ -154,7 +177,10 @@ class Term_Importer extends Importer {
 		}
 
 		$position_file = $this->get_in_step_count();
-		fseek($file, $position_file);
+		// Avoid seeking to 0 after open_tmp_file(), which already skipped a UTF-8 BOM when present.
+		if ( $position_file > 0 ) {
+			fseek($file, $position_file);
+		}
 		if (($values =  fgetcsv($file, 0, $this->get_option('delimiter'), '"')) !== FALSE) {
 			$position_file = ftell($file);
 			if ($values[$position] == '') { // next degree

--- a/tests/test-importer.php
+++ b/tests/test-importer.php
@@ -575,4 +575,40 @@ class ImporterTests extends TAINACAN_UnitTestCase {
 		//  }
 		//}
 	}
+
+	/**
+	 * UTF-8 BOM on the first column must not break special field detection.
+	 *
+	 * @group importer_csv_special_fields
+	 */
+	public function test_utf8_bom_special_item_id() {
+		$Tainacan_Importer_Handler = \Tainacan\Importer_Handler::get_instance();
+		$file_name = 'demosaved_bom.csv';
+		$csv_importer = $Tainacan_Importer_Handler->initialize_importer('csv');
+		$Tainacan_Importer_Handler->save_importer_instance($csv_importer);
+		$id = $csv_importer->get_id();
+		$importer_instance = $Tainacan_Importer_Handler->get_importer_instance_by_session_id($id);
+
+		$file = fopen($file_name, 'w');
+		fwrite($file, "\xEF\xBB\xBF");
+		fputcsv($file, array('special_item_id', 'Column 1', 'Column 2'));
+		fputcsv($file, array('101', 'Data 11', 'Data 12'));
+		fputcsv($file, array('102', 'Data 21', 'Data 22'));
+		fclose($file);
+
+		$importer_instance->set_tmp_file( $file_name );
+
+		$this->assertEquals( 2, $importer_instance->get_source_number_of_items() );
+
+		$raw_headers = $importer_instance->raw_source_metadata();
+		$this->assertEquals( 'special_item_id', $raw_headers[0] );
+		$this->assertStringNotContainsString( "\xEF\xBB\xBF", $raw_headers[0] );
+
+		$headers = $importer_instance->get_source_metadata();
+		$this->assertEquals( array( 'Column 1', 'Column 2' ), $headers );
+		$this->assertEquals( 0, $importer_instance->get_option('item_id_index') );
+
+		$special_fields = $importer_instance->get_source_special_fields();
+		$this->assertEquals( array( 'special_item_id' ), $special_fields );
+	}
 }


### PR DESCRIPTION
## Description

Skips a leading UTF-8 BOM (`EF BB BF`) when opening CSV files in the items and terms importers.

Excel and similar tools often save UTF-8 CSVs with a BOM. That prefix was being read as part of the first column name (e.g. `\xEF\xBB\xBFspecial_item_id`), so exact matches for special fields failed and columns like `special_item_id` were treated as normal metadata in the mapping step.

Both CSV-related importers now open the temp file through a local `open_tmp_file()` helper that consumes the BOM when present. A regression test covers BOM + `special_item_id` detection. Test artifact `demosaved_bom.csv` was added to `.gitignore`.

## Related issue

Closes #1103

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would change existing behavior)
- [ ] Refactor / technical debt (no user-facing change)
- [ ] Documentation

## Checklist

- [x] My code follows the project's coding standards (ESLint / PHPCS)
- [x] I have tested my changes locally
- [x] I have added or updated tests when applicable
- [ ] If I changed a Gutenberg block's `block.json` or `save.js`, I updated the corresponding `deprecated.js`
- [ ] I have updated the documentation when needed
- [ ] For UI changes, I have added screenshots or a screen recording below

## Screenshots / recordings

N/A (backend CSV parsing fix; no UI changes)