### PR TITLE
fix: Adds more opinated styles to allow overriding b-steps color

### DIFF
--- a/src/views/gutenberg-blocks/blocks/item-submission-form/theme.vue
+++ b/src/views/gutenberg-blocks/blocks/item-submission-form/theme.vue
@@ -464,7 +464,6 @@
                     ref="item-submission-steps-layout"
                     v-model="activeSectionStep"
                     :has-navigation="false"
-                    type="is-secondary"
                     mobile-mode="compact"
                     size="is-small">
                 <component
@@ -1718,8 +1717,9 @@ export default {
 
     .b-steps {
         border: 1px solid var(--tainacan-input-border-color);
-        border-radius: 2px;
-        margin-top: 1em;
+        border-radius: var(--tainacan-input-border-radius);
+        margin-top: 1.75em;
+        --bulma-primary: var(--tainacan-secondary);
 
         .step-items {
             margin-top: -1em;
@@ -1728,11 +1728,31 @@ export default {
             padding-left: 0px;
             margin-left: 0px;
 
-            .step-item.is-active .step-title {
-                color: var(--tainacan-secondary);
+            .step-item.is-active {
+                .step-title {
+                    color: var(--tainacan-secondary);
+                }
+                .step-marker {
+                    border-color: var(--tainacan-secondary);
+                    color: var(--tainacan-secondary);
+                }
             }
-            .step-item:not(.is-active) .step-title {
-                color: var(--tainacan-label-color);
+            .step-item:not(.is-active) {
+                .step-title {
+                    color: var(--tainacan-label-color);
+                }
+                .step-marker {
+                    background-color: var(--tainacan-label-color);
+                }
+            }
+            .step-item:not(.is-active).is-previous {
+                .step-title {
+                    color: var(--tainacan-info-color);
+                }
+                .step-marker {
+                    background-color: var(--tainacan-info-color);
+                    color: var(--tainacan-input-background-color);
+                }
             }
             .step-link,
             .step-link:hover {


### PR DESCRIPTION
## Description

Overrides Bulma variable and classes in the Buefy Steps component to avoid having the `is-secondary` background issue and other conflicts that arise from their new CSS variables scheme. This bug was probably introduced during the #945 migration.

## Related issue

Closes #1108

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would change existing behavior)
- [ ] Refactor / technical debt (no user-facing change)
- [ ] Documentation

## Checklist

- [x] My code follows the project's coding standards (ESLint / PHPCS)
- [x] I have tested my changes locally
- [ ] I have added or updated tests when applicable
- [ ] If I changed a Gutenberg block's `block.json` or `save.js`, I updated the corresponding `deprecated.js`
- [ ] I have updated the documentation when needed
- [ ] For UI changes, I have added screenshots or a screen recording below

## Screenshots / recordings

<img width="1228" height="184" alt="image" src="https://github.com/user-attachments/assets/d8cf8a60-4bac-4b51-a0bc-c765e2d0e679" />