### PR TITLE
fix: Avoids passing string null values in metadata mapping and only c…

### DIFF
--- a/src/classes/background-process/importer/class-tainacan-csv.php
+++ b/src/classes/background-process/importer/class-tainacan-csv.php
@@ -1207,11 +1207,18 @@ class CSV extends Importer {
 				foreach( $collection['mapping'] as $metadatum_id => $header ){
 
 					if (!is_numeric($metadatum_id)) {
-						$repo_key = "create_repository_metadata";
-						$collection_id = $collection['id'];
-						if (strpos($metadatum_id, $repo_key) !== false) {
-							$collection_id = "default";
+						$metadatum_id_str = (string) $metadatum_id;
+						$is_create_collection = strpos( $metadatum_id_str, 'create_metadata' ) === 0;
+						$is_create_repository = strpos( $metadatum_id_str, 'create_repository_metadata' ) === 0;
+
+						// Ignore empty/placeholder mapping keys (e.g. "null", "") instead of
+						// treating every non-numeric key as a request to create metadata.
+						if ( ! $is_create_collection && ! $is_create_repository ) {
+							unset( $collection['mapping'][ $metadatum_id ] );
+							continue;
 						}
+
+						$collection_id = $is_create_repository ? 'default' : $collection['id'];
 						$metadatum = $this->create_new_metadata($header, $collection_id);
 
 						if ($metadatum == false) {

--- a/src/views/admin/components/edition/importer-mapping-form.vue
+++ b/src/views/admin/components/edition/importer-mapping-form.vue
@@ -723,15 +723,18 @@ export default {
             if (removedKey != '')
                 delete this.mappedCollection['mapping'][removedKey];
 
-            let mappingValue;
-            if (isCompound) {
-                mappingValue = {} 
-                mappingValue[sourceMetadatum] = childSourceMetadata;
-                
-            } else {
-                mappingValue = sourceMetadatum;
+            // Empty placeholder ("Select a metadatum") must leave the column unmapped.
+            if (selectedMetadatum) {
+                let mappingValue;
+                if (isCompound) {
+                    mappingValue = {} 
+                    mappingValue[sourceMetadatum] = childSourceMetadata;
+                    
+                } else {
+                    mappingValue = sourceMetadatum;
+                }
+                this.mappedCollection['mapping'][selectedMetadatum] = mappingValue;
             }
-            this.mappedCollection['mapping'][selectedMetadatum] = mappingValue;
 
             // Necessary for causing reactivity to re-check if metadata remains available
             this.collectionMetadata.push("");


### PR DESCRIPTION
…reate new ones when explicitly sent to the backend

## Description

Fixes CSV importer mapping so columns left on the empty “Select a metadatum” placeholder are ignored instead of creating metadata and importing values.

**Frontend:** `onSelectCollectionMetadata` in `importer-mapping-form.vue` no longer writes a mapping entry when the placeholder (`null`) is selected. It still removes any previous mapping for that column (same behavior as the child-metadata handler).

**Backend:** `CSV::add_collection()` only auto-creates metadata for keys that start with `create_metadata` or `create_repository_metadata`. Other non-numeric keys (e.g. `"null"`, `""`) are dropped from the mapping instead of triggering `create_new_metadata()`.

## Related issue

Closes #

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would change existing behavior)
- [ ] Refactor / technical debt (no user-facing change)
- [ ] Documentation

## Checklist

- [x] My code follows the project's coding standards (ESLint / PHPCS)
- [x] I have tested my changes locally
- [ ] I have added or updated tests when applicable
- [ ] If I changed a Gutenberg block's `block.json` or `save.js`, I updated the corresponding `deprecated.js`
- [ ] I have updated the documentation when needed
- [ ] For UI changes, I have added screenshots or a screen recording below