### PR TITLE
fix: lazy-load and scope Tainacan video embeds

### DIFF
--- a/src/classes/entities/class-tainacan-item.php
+++ b/src/classes/entities/class-tainacan-item.php
@@ -915,8 +915,8 @@ class Item extends Entity {
 		$output = '';
 		
 		if ( $type == 'url' ) {
-			global $wp_embed;
-			$_embed = $wp_embed->autoembed($this->get_document());
+			$tainacan_embed = \Tainacan\Embed::get_instance();
+			$_embed = $tainacan_embed->embed( $this->get_document() );
 			$url = $this->get_document();
 
 			if ( esc_url($_embed) == esc_url($url) ) {
@@ -942,7 +942,6 @@ class Item extends Entity {
 					$_embed = sprintf('<a href="%s" target="blank">%s</a>', $url, $url);
 				}
 			} else {
-				$tainacan_embed = \Tainacan\Embed::get_instance();
 				$_embed = $tainacan_embed->add_responsive_wrapper($_embed);
 			}
 			$output = $_embed;
@@ -972,16 +971,14 @@ class Item extends Entity {
 			
 		} else {
 
-			global $wp_embed;
-
 			$url = wp_get_attachment_url($attachment);
 
-			$embed = $wp_embed->autoembed($url);
+			$tainacan_embed = \Tainacan\Embed::get_instance();
+			$embed = $tainacan_embed->embed( $url );
 
 			if ( esc_url($embed) == esc_url($url) ) {
 				$output .= sprintf("<a href='%s' target='blank'>%s</a>", $url, $url);
 			} else {
-				$tainacan_embed = \Tainacan\Embed::get_instance();
 				$embed = $tainacan_embed->add_responsive_wrapper($embed);
 				$output .= $embed;
 			}

--- a/src/classes/media-helper/class-tainacan-embed.php
+++ b/src/classes/media-helper/class-tainacan-embed.php
@@ -120,7 +120,7 @@ class Embed {
 	 * @return bool Whether the preload="none" attribute should be rendered.
 	 */
 	private function is_video_preload_none_enabled() {
-		return rest_sanitize_boolean( get_option( 'tainacan_option_enable_video_preload_none', true ) );
+		return rest_sanitize_boolean( get_option( 'tainacan_option_enable_video_preload_none', false ) );
 	}
 	
 	/**

--- a/src/classes/media-helper/class-tainacan-embed.php
+++ b/src/classes/media-helper/class-tainacan-embed.php
@@ -16,6 +16,21 @@ class Embed {
 	use \Tainacan\Traits\Singleton_Instance;
 
 	/**
+	 * Whether Tainacan's custom video/audio markup should be applied to the
+	 * current autoembed() call.
+	 *
+	 * The wp_embed_handler_video/audio filters are registered once at plugin
+	 * load, but they must only take effect when Tainacan itself is embedding
+	 * media (Tainacan admin item pages, item single pages, the media page and
+	 * the URL metadata type). This flag is toggled by Embed::embed() so the
+	 * override never leaks into unrelated WordPress content.
+	 *
+	 * @since 1.0.0
+	 * @var bool
+	 */
+	private static $override_active = false;
+
+	/**
 	 * Available aspect ratios for responsive embeds.
 	 *
 	 * @since 0.1.0
@@ -80,13 +95,19 @@ class Embed {
 	 */
 	public function filter_video_embed($video, $attr, $url, $rawattr) {
 		
+		// Only apply Tainacan's video markup while Tainacan is embedding its own content.
+		if ( ! self::$override_active ) {
+			return $video;
+		}
 		
 		$dimensions = '';
 		if ( ! empty( $attr['width'] ) && ! empty( $attr['height'] ) ) {
 			$dimensions .= sprintf( 'width="%d" ', (int) $attr['width'] );
 			//$dimensions .= sprintf( 'height="%d" ', (int) $attr['height'] );
 		}
-		$video = sprintf( '<video controls="" %s src="%s"></video>', $dimensions, esc_url( $url ) );
+		// preload="none" avoids loading the video as soon as the tag is rendered,
+		// which prevents CPU/memory spikes on some servers.
+		$video = sprintf( '<video controls="" preload="none" %s src="%s"></video>', $dimensions, esc_url( $url ) );
 		
 		return $video;
 		
@@ -105,6 +126,11 @@ class Embed {
 	 */
 	public function filter_audio_embed($audio, $attr, $url, $rawattr) {
 		
+		// Only apply Tainacan's audio markup while Tainacan is embedding its own content.
+		if ( ! self::$override_active ) {
+			return $audio;
+		}
+		
 		if ( ! empty( $attr['width'] ) ) {
 			$dimensions = sprintf( 'width="%d" ', (int) $attr['width'] );
 		}
@@ -115,6 +141,31 @@ class Embed {
 		
 	}
 	
+	/**
+	 * Runs WordPress autoembed on a URL while applying Tainacan's custom
+	 * video/audio markup.
+	 *
+	 * WordPress processes media URLs in content through the registered embed
+	 * handlers. Tainacan's own markup must only be produced for media that
+	 * Tainacan itself embeds (item documents, attachments, URL metadata and
+	 * the media page), never for unrelated WordPress content. This wrapper
+	 * scopes the override to exactly those calls.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param string $url The URL to embed.
+	 * @return string The embed HTML, or the original URL when autoembed fails.
+	 */
+	public function embed( $url ) {
+		global $wp_embed;
+
+		self::$override_active = true;
+		$embed = $wp_embed->autoembed( $url );
+		self::$override_active = false;
+
+		return $embed;
+	}
+
 	/**
 	 * Handles PDF file embedding using iframe.
 	 *

--- a/src/classes/media-helper/class-tainacan-embed.php
+++ b/src/classes/media-helper/class-tainacan-embed.php
@@ -105,12 +105,22 @@ class Embed {
 			$dimensions .= sprintf( 'width="%d" ', (int) $attr['width'] );
 			//$dimensions .= sprintf( 'height="%d" ', (int) $attr['height'] );
 		}
-		// preload="none" avoids loading the video as soon as the tag is rendered,
-		// which prevents CPU/memory spikes on some servers.
-		$video = sprintf( '<video controls="" preload="none" %s src="%s"></video>', $dimensions, esc_url( $url ) );
+		$preload = $this->is_video_preload_none_enabled() ? 'preload="none" ' : '';
+		$video = sprintf( '<video controls="" %s%s src="%s"></video>', $preload, $dimensions, esc_url( $url ) );
 		
 		return $video;
 		
+	}
+
+	/**
+	 * Checks whether Tainacan videos should prevent browser preloading.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @return bool Whether the preload="none" attribute should be rendered.
+	 */
+	private function is_video_preload_none_enabled() {
+		return rest_sanitize_boolean( get_option( 'tainacan_option_enable_video_preload_none', true ) );
 	}
 	
 	/**
@@ -159,11 +169,15 @@ class Embed {
 	public function embed( $url ) {
 		global $wp_embed;
 
+		$previous_override_active = self::$override_active;
 		self::$override_active = true;
-		$embed = $wp_embed->autoembed( $url );
-		self::$override_active = false;
 
-		return $embed;
+		try {
+			return $wp_embed->autoembed( $url );
+		} finally {
+			self::$override_active = $previous_override_active;
+		}
+
 	}
 
 	/**

--- a/src/classes/media-helper/class-tainacan-media.php
+++ b/src/classes/media-helper/class-tainacan-media.php
@@ -746,11 +746,11 @@ class Media {
 		} else {
 			$this->add_css();
 			wp_print_styles('tainacan-media-page');
-			global $wp_embed;
 
 			$url = wp_get_attachment_url($att_id);
 
-			$embed = $wp_embed->autoembed($url);
+			$tainacan_embed = \Tainacan\Embed::get_instance();
+			$embed = $tainacan_embed->embed( $url );
 
 			if ( esc_url($embed) == esc_url($url) ) {
 				$output .= sprintf("<a href='%s' target='blank'>%s</a>", $url, $url);

--- a/src/views/admin/components/metadata-types/url/class-tainacan-url.php
+++ b/src/views/admin/components/metadata-types/url/class-tainacan-url.php
@@ -132,7 +132,6 @@ class URL extends Metadata_Type {
 	 * @return string
 	 */
 	public function get_single_value_as_html($value) {
-		global $wp_embed;
 
 		$link_as_button = $this->get_option('link-as-button') == 'yes';
 		$return = '';
@@ -147,7 +146,8 @@ class URL extends Metadata_Type {
 		} else {
 
 			// First, we try WordPress autoembed
-			$embed = $wp_embed->autoembed($value);
+			$tainacan_embed = \Tainacan\Embed::get_instance();
+			$embed = $tainacan_embed->embed( $value );
 			
 			// If it didn't work, it will still ba a URL
  			if ( esc_url($embed) == esc_url($value) ) {

--- a/src/views/settings/class-tainacan-settings.php
+++ b/src/views/settings/class-tainacan-settings.php
@@ -171,6 +171,18 @@ class Settings extends Pages {
 				: null
 		) );
 
+		$this->create_tainacan_setting( array(
+			'id' => 'enable_video_preload_none',
+			'section' => 'tainacan_settings_search_and_performance',
+			'title' => __( 'Video preload', 'tainacan' ),
+			'label' => __( 'Prevent videos from preloading', 'tainacan' ),
+			'description' => __( 'When enabled, Tainacan videos use the preload="none" attribute and load only after the visitor starts playback. Disable this option to let the browser use its default video preload behavior.', 'tainacan' ),
+			'type' => 'boolean',
+			'input_type' => 'checkbox',
+			'sanitize_callback' => 'rest_sanitize_boolean',
+			'default' => true
+		) );
+
 		/**
 		 * Theme default templates -----------------------------------------------------
 		 */

--- a/src/views/settings/class-tainacan-settings.php
+++ b/src/views/settings/class-tainacan-settings.php
@@ -180,7 +180,7 @@ class Settings extends Pages {
 			'type' => 'boolean',
 			'input_type' => 'checkbox',
 			'sanitize_callback' => 'rest_sanitize_boolean',
-			'default' => true
+			'default' => false
 		) );
 
 		/**

--- a/tests/test-video-embed.php
+++ b/tests/test-video-embed.php
@@ -31,10 +31,10 @@ class VideoEmbed extends TAINACAN_UnitTestCase {
 				$embed->filter_video_embed( $default_video, array(), 'https://example.com/video.mp4', array() )
 			);
 
-			$this->assertStringContainsString( 'preload="none"', $embed->embed( 'https://example.com/video.mp4' ) );
-
-			update_option( 'tainacan_option_enable_video_preload_none', '0' );
 			$this->assertStringNotContainsString( 'preload=', $embed->embed( 'https://example.com/video.mp4' ) );
+
+			update_option( 'tainacan_option_enable_video_preload_none', '1' );
+			$this->assertStringContainsString( 'preload="none"', $embed->embed( 'https://example.com/video.mp4' ) );
 		} finally {
 			delete_option( 'tainacan_option_enable_video_preload_none' );
 			$wp_embed = $previous_wp_embed;

--- a/tests/test-video-embed.php
+++ b/tests/test-video-embed.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace Tainacan\Tests;
+
+/**
+ * Tests the scoped video embed output.
+ */
+class VideoEmbed extends TAINACAN_UnitTestCase {
+
+	public function test_video_preload_setting_only_affects_tainacan_embeds() {
+		global $wp_embed;
+
+		$embed = \Tainacan\Embed::get_instance();
+		$default_video = '<video class="wp-default"></video>';
+		$previous_wp_embed = $wp_embed;
+		$wp_embed = new class {
+			public function autoembed( $url ) {
+				return \Tainacan\Embed::get_instance()->filter_video_embed(
+					'<video class="wp-default"></video>',
+					array( 'width' => 640, 'height' => 360 ),
+					$url,
+					array()
+				);
+			}
+		};
+
+		try {
+			delete_option( 'tainacan_option_enable_video_preload_none' );
+			$this->assertSame(
+				$default_video,
+				$embed->filter_video_embed( $default_video, array(), 'https://example.com/video.mp4', array() )
+			);
+
+			$this->assertStringContainsString( 'preload="none"', $embed->embed( 'https://example.com/video.mp4' ) );
+
+			update_option( 'tainacan_option_enable_video_preload_none', '0' );
+			$this->assertStringNotContainsString( 'preload=', $embed->embed( 'https://example.com/video.mp4' ) );
+		} finally {
+			delete_option( 'tainacan_option_enable_video_preload_none' );
+			$wp_embed = $previous_wp_embed;
+		}
+	}
+}


### PR DESCRIPTION
## Summary

Addresses #1093.

This PR fixes Tainacan video embed loading spikes and keeps the embed behavior scoped
to Tainacan-controlled content.

### Preload and scope

- Tainacan-created video elements use `preload="none"` when the Video preload option is enabled.
- The `wp_embed_handler_video` and `wp_embed_handler_audio` overrides are active only
  while Tainacan runs its own embed wrapper.
- Tainacan item documents, attachments, media pages, and URL metadata pass through
  the scoped wrapper.
- Ordinary WordPress embeds retain WordPress's default output.

### Configuration option

- A **Video preload** checkbox is the final setting under **Other > Configurations > Search and performance**.
- It is disabled by default, preserving the browser's standard video preload behavior.
- When disabled, Tainacan renders the video element with no `preload` attribute, allowing the browser's default behavior.
- This option does not broaden the override: only videos embedded through Tainacan's scoped embed wrapper are affected.
