### PR TITLE
fix: Remove CSV importer files after process completion

### DIFF
--- a/src/classes/api/endpoints/class-tainacan-rest-background-processes-controller.php
+++ b/src/classes/api/endpoints/class-tainacan-rest-background-processes-controller.php
@@ -322,9 +322,24 @@ class REST_Background_Processes_Controller extends REST_Controller {
             }
         }
 
-        $query = "UPDATE $this->table SET $status_q WHERE 1=1 $id_q $user_q";
+        $query = "SELECT * FROM $this->table WHERE 1=1 $id_q $user_q LIMIT 1";
 
-        $result = $wpdb->query($query);
+        $result = $wpdb->get_row($query);
+
+        if ( ! $result ) {
+            return new \WP_REST_Response([
+                'error_message' => __('Background process not found', 'tainacan' ),
+                'session_id' => $id
+            ], 404);
+        }
+
+        if ( $body['status'] === 'closed' && $result->action === 'import' ) {
+            $background_importer = new \Tainacan\Background_Importer();
+            $background_importer->close( $result->ID, 'cancelled' );
+        } else {
+            $query = "UPDATE $this->table SET $status_q WHERE 1=1 $id_q $user_q";
+            $wpdb->query($query);
+        }
 
         $query = "SELECT * FROM $this->table WHERE 1=1 $id_q $user_q LIMIT 1";
 

--- a/src/classes/background-process/importer/class-tainacan-bg-importer.php
+++ b/src/classes/background-process/importer/class-tainacan-bg-importer.php
@@ -33,6 +33,40 @@ class Background_Importer extends Background_Process {
 	private function set_finish_status( $status ){
 		$this->finish_status = $status;
 	}
+
+	public function close( $key, $status = 'finished' ) {
+
+		$batch = $this->get_batch_by_key( $key );
+		$data = $batch->data;
+
+		if (
+			! empty( $data['tmp_file_id'] ) &&
+			! empty( $data['class_name'] ) &&
+			class_exists( $data['class_name'] )
+		) {
+			$class_name = $data['class_name'];
+			$importer = new $class_name( $data );
+
+			if (
+				method_exists( $importer, 'delete_source_file' ) &&
+				! $importer->delete_source_file()
+			) {
+				$this->write_error_log(
+					$key,
+					[[
+						'datetime' => date( 'Y-m-d H:i:s' ),
+						'message'  => 'Failed to delete importer source file.'
+					]]
+				);
+
+				if ( $status === 'finished' ) {
+					$status = 'finished-errors';
+				}
+			}
+		}
+
+		return parent::close( $key, $status );
+	}
 	
 	function task($batch) {
 
@@ -67,7 +101,6 @@ class Background_Importer extends Background_Process {
 			return $batch;
 		}
 		return false;
-		
 		
 	}
 

--- a/src/classes/background-process/importer/class-tainacan-importer.php
+++ b/src/classes/background-process/importer/class-tainacan-importer.php
@@ -25,6 +25,12 @@ abstract class Importer {
 	 */
 	protected $tmp_file;
 
+	/**
+	 * WordPress attachment ID of the uploaded source file.
+	 *
+	 * @var int
+	 */
+	protected $tmp_file_id;
 
 	/**
 	 * This array holds the structure that the default step 'process_collections' will handle.
@@ -137,7 +143,8 @@ abstract class Importer {
 		'transients',
 		'options',
 		'collections',
-		'tmp_file'
+		'tmp_file',
+		'tmp_file_id'
 	];
 
 	public function __construct($attributes = array()) {
@@ -256,6 +263,14 @@ abstract class Importer {
 		$this->tmp_file = $filepath;
 	}
 
+	public function get_tmp_file_id(){
+		return $this->tmp_file_id;
+	}
+
+	public function set_tmp_file_id($id){
+		$this->tmp_file_id = $id;
+	}
+
 	public function get_collections() {
 		return $this->collections;
 	}
@@ -328,12 +343,34 @@ abstract class Importer {
 		$new_file = $this->upload_file( $file );
 		if ( is_numeric( $new_file ) ) {
 			$this->tmp_file = get_attached_file( $new_file );
+			$this->tmp_file_id = (int) $new_file;
 			return true;
 		} else {
 			return false;
 		}
 	}
 
+	/**
+	 * Delete the uploaded source file and its WordPress attachment.
+	 *
+	 * @return bool
+	 */
+	public function delete_source_file() {
+
+		if ( empty( $this->tmp_file_id ) ) {
+			return false;
+		}
+
+		$deleted = wp_delete_attachment( $this->tmp_file_id, true );
+
+		if ( $deleted ) {
+			$this->tmp_file = null;
+			$this->tmp_file_id = null;
+			return true;
+		}
+
+		return false;
+	}
 
 	/**
 	 * log the actions from importer

--- a/src/classes/class-tainacan-private-files.php
+++ b/src/classes/class-tainacan-private-files.php
@@ -178,7 +178,7 @@ class Private_Files {
 
 		$post = get_post($post_id);
 
-		if ( !$theme_helper->is_post_an_item($post) ) {
+		if ( ! ( $post instanceof \WP_Post ) || ! $theme_helper->is_post_an_item($post) ) {
 			return $path;
 		}
 

--- a/tests/test-importer.php
+++ b/tests/test-importer.php
@@ -115,6 +115,125 @@ class ImporterTests extends TAINACAN_UnitTestCase {
 	/**
 	 * @group importer
 	 */
+	public function test_source_file_is_removed_when_background_import_finishes() {
+		$this->assert_source_file_is_removed_when_background_import_closes( 'finished' );
+	}
+
+	/**
+	 * @group importer
+	 */
+	public function test_source_file_is_removed_when_background_import_finishes_with_errors() {
+		$this->assert_source_file_is_removed_when_background_import_closes( 'finished-errors' );
+	}
+
+	/**
+	 * @group importer
+	 */
+	public function test_source_file_is_removed_when_background_import_errors() {
+		$this->assert_source_file_is_removed_when_background_import_closes( 'errored' );
+	}
+
+	/**
+	 * @group importer
+	 */
+	public function test_source_file_is_removed_when_background_import_is_cancelled() {
+		$this->assert_source_file_is_removed_when_background_import_closes( 'cancelled', 'csv', true );
+	}
+
+	private function assert_source_file_is_removed_when_background_import_closes( $status, $importer_slug = 'csv', $cancel_via_api = false ) {
+		$file_name = wp_tempnam( 'issue-1091.csv' );
+		$this->assertNotFalse( $file_name );
+
+		$file = fopen( $file_name, 'w' );
+		fputcsv( $file, [ 'Name' ] );
+		fputcsv( $file, [ 'Item 1' ] );
+		fclose( $file );
+
+		$handler = \Tainacan\Importer_Handler::get_instance();
+		$importer = $handler->initialize_importer( $importer_slug );
+
+		$file_array = [
+			'name'     => 'issue-1091.csv',
+			'type'     => 'text/csv',
+			'tmp_name' => $file_name,
+			'error'    => 0,
+			'size'     => filesize( $file_name ),
+		];
+
+		$this->assertTrue( $importer->add_file( $file_array ) );
+
+		$uploaded_file = $importer->get_tmp_file();
+		$this->assertFileExists( $uploaded_file );
+
+		$attachment_ids = get_posts( [
+			'post_type'      => 'attachment',
+			'post_status'    => 'inherit',
+			'posts_per_page' => 1,
+			'fields'         => 'ids',
+			'meta_key'       => '_wp_attached_file',
+			'meta_value'     => _wp_relative_upload_path( $uploaded_file ),
+		] );
+
+		$this->assertNotEmpty( $attachment_ids );
+		$attachment_id = (int) $attachment_ids[0];
+
+		$background_importer = new \Tainacan\Background_Importer();
+
+		$background_importer
+			->data( $importer->_to_Array( true ) )
+			->set_name( 'CSV Importer' )
+			->save();
+
+		$process_id = $background_importer->ID;
+
+		if ( $cancel_via_api ) {
+			$request = new \WP_REST_Request( 'POST', '/' );
+			$request->set_param( 'id', $process_id );
+			$request->set_body( wp_json_encode( [ 'status' => 'closed' ] ) );
+
+			$controller = new \Tainacan\API\EndPoints\REST_Background_Processes_Controller();
+			$response = $controller->update_item( $request );
+
+			$this->assertEquals( 200, $response->get_status() );
+			$response_data = $response->get_data();
+			$this->assertEquals( 'cancelled', $response_data->status );
+		} else {
+			$background_importer->close( $process_id, $status );
+		}
+
+		$file_exists_after_close = file_exists( $uploaded_file );
+		$attachment_after_close = get_post( $attachment_id );
+
+		// Prevent test artifacts from remaining when an assertion fails.
+		$background_importer->delete( $process_id );
+
+		if ( $attachment_after_close ) {
+			wp_delete_attachment( $attachment_id, true );
+		} elseif ( $file_exists_after_close ) {
+			wp_delete_file( $uploaded_file );
+		}
+
+		$this->assertFalse(
+			$file_exists_after_close,
+			'The importer source file should be removed when the background import reaches a terminal state.'
+		);
+
+		$this->assertNull(
+			$attachment_after_close,
+			'The WordPress attachment should also be removed when the background import reaches a terminal state.'
+		);
+	}
+
+	/**
+	 * @group importer
+	 */
+	public function test_vocabulary_csv_source_file_is_removed_when_background_import_finishes() {
+		$this->assert_source_file_is_removed_when_background_import_closes( 'finished', 'terms' );
+	}
+
+	/**
+	 * @group importer
+	 */
 	/*
 	public function test_fetch_file(){
 		$csv_importer = new Importer\CSV();
@@ -241,7 +360,6 @@ class ImporterTests extends TAINACAN_UnitTestCase {
 			true
 		);
 
-		
 		$collection_definition = [
 			'id' => $collection->get_id(),
 			'total_items' => $importer_instance->get_source_number_of_items(),
@@ -449,7 +567,6 @@ class ImporterTests extends TAINACAN_UnitTestCase {
 		$this->assertFalse( is_numeric($document_id) );
 
 	}
-
 
 	/**
 	 * @group importer_csv_special_fields


### PR DESCRIPTION
## Description

Preserves the WordPress attachment ID of uploaded importer source files and removes the source CSV when the background import reaches a terminal state.

The cleanup removes the physical file, its attachment record, and related metadata for `finished`, `finished-errors`, `errored`, and `cancelled` processes. Cancellation from the Processes screen now uses the same terminal cleanup routine.

Cleanup failures are written to the error log and change a normal completion to `finished-errors`. Process history, activities, imported filename, and log files remain available.

The change covers CSV item imports and CSV Vocabulary imports. Importers without source files are not affected.

## Related issue

Closes #1091

## Type of change

* [x] Bug fix (non-breaking change which fixes an issue)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would change existing behavior)
* [ ] Refactor / technical debt (no user-facing change)
* [ ] Documentation

## Checklist

* [ ] My code follows the project's coding standards (ESLint / PHPCS)
* [x] I have tested my changes locally
* [x] I have added or updated tests when applicable
* [x] If I changed a Gutenberg block's `block.json` or `save.js`, I updated the corresponding `deprecated.js`
* [x] I have updated the documentation when needed
* [x] For UI changes, I have added screenshots or a screen recording below

## Test results

* `phpunit --filter ImporterTests`
* 11 tests and 79 assertions passing
* Manual CSV import creating new items
* Manual CSV import updating existing items
* Manual CSV Vocabulary import
* Confirmed removal of the physical CSV, attachment record, and related post metadata
* Confirmed that process history and logs remain available
* PHP syntax checks and `git diff --check` passed
* PHPCS could not run locally because the `WordPress-Core` and `WordPress-Docs` sniffs are not installed in the current development environment

## Screenshots / recordings

Not applicable. This change does not modify the user interface.