### PR TITLE
feat: lazy-load Tainacan video embeds using the item's thumbnail

### DIFF
--- a/src/classes/entities/class-tainacan-item.php
+++ b/src/classes/entities/class-tainacan-item.php
@@ -974,7 +974,8 @@ class Item extends Entity {
 			$url = wp_get_attachment_url($attachment);
 
 			$tainacan_embed = \Tainacan\Embed::get_instance();
-			$embed = $tainacan_embed->embed( $url, $this );
+			$is_main_document = $this->get_document_type() === 'attachment' && (int) $this->get_document() === (int) $attachment;
+			$embed = $tainacan_embed->embed( $url, $is_main_document ? $this : null );
 
 			if ( esc_url($embed) == esc_url($url) ) {
 				$output .= sprintf("<a href='%s' target='blank'>%s</a>", $url, $url);

--- a/src/classes/entities/class-tainacan-item.php
+++ b/src/classes/entities/class-tainacan-item.php
@@ -975,7 +975,11 @@ class Item extends Entity {
 
 			$tainacan_embed = \Tainacan\Embed::get_instance();
 			$is_main_document = $this->get_document_type() === 'attachment' && (int) $this->get_document() === (int) $attachment;
-			$embed = $tainacan_embed->embed( $url, $is_main_document ? $this : null );
+			$companion_thumbnail = null;
+			if ( ! $is_main_document && wp_attachment_is( 'video', $attachment ) ) {
+				$companion_thumbnail = $tainacan_embed->get_video_companion_thumbnail( $attachment );
+			}
+			$embed = $tainacan_embed->embed( $url, $this, $companion_thumbnail );
 
 			if ( esc_url($embed) == esc_url($url) ) {
 				$output .= sprintf("<a href='%s' target='blank'>%s</a>", $url, $url);

--- a/src/classes/entities/class-tainacan-item.php
+++ b/src/classes/entities/class-tainacan-item.php
@@ -915,8 +915,8 @@ class Item extends Entity {
 		$output = '';
 		
 		if ( $type == 'url' ) {
-			global $wp_embed;
-			$_embed = $wp_embed->autoembed($this->get_document());
+			$tainacan_embed = \Tainacan\Embed::get_instance();
+			$_embed = $tainacan_embed->embed( $this->get_document(), $this );
 			$url = $this->get_document();
 
 			if ( esc_url($_embed) == esc_url($url) ) {
@@ -942,7 +942,6 @@ class Item extends Entity {
 					$_embed = sprintf('<a href="%s" target="blank">%s</a>', $url, $url);
 				}
 			} else {
-				$tainacan_embed = \Tainacan\Embed::get_instance();
 				$_embed = $tainacan_embed->add_responsive_wrapper($_embed);
 			}
 			$output = $_embed;
@@ -972,16 +971,14 @@ class Item extends Entity {
 			
 		} else {
 
-			global $wp_embed;
-
 			$url = wp_get_attachment_url($attachment);
 
-			$embed = $wp_embed->autoembed($url);
+			$tainacan_embed = \Tainacan\Embed::get_instance();
+			$embed = $tainacan_embed->embed( $url, $this );
 
 			if ( esc_url($embed) == esc_url($url) ) {
 				$output .= sprintf("<a href='%s' target='blank'>%s</a>", $url, $url);
 			} else {
-				$tainacan_embed = \Tainacan\Embed::get_instance();
 				$embed = $tainacan_embed->add_responsive_wrapper($embed);
 				$output .= $embed;
 			}

--- a/src/classes/media-helper/class-tainacan-embed.php
+++ b/src/classes/media-helper/class-tainacan-embed.php
@@ -39,6 +39,16 @@ class Embed {
 	private static $override_item = null;
 
 	/**
+	 * Explicit thumbnail for the current autoembed() call, taking precedence
+	 * over the item thumbnail (e.g. an image attachment paired with a video
+	 * file by sharing the same file name).
+	 *
+	 * @since 1.0.0
+	 * @var array|null
+	 */
+	private static $override_thumbnail = null;
+
+	/**
 	 * Available aspect ratios for responsive embeds.
 	 *
 	 * @since 0.1.0
@@ -87,6 +97,12 @@ class Embed {
 		 * @var [type]
 		 */
 		wp_embed_register_handler( 'pdf', '#^https?://.+?\.(pdf)$#i', [$this, 'pdf_embed_handler'] );
+
+		/**
+		 * Hide image attachments that serve as miniatures for sibling videos
+		 * from the item gallery, as they are displayed in the video place.
+		 */
+		add_filter( 'tainacan-get-the-attachments', [ $this, 'filter_video_companion_images' ], 10, 2 );
 
 	}
 	
@@ -215,9 +231,17 @@ class Embed {
 	 * @return array Thumbnail URL and dimensions.
 	 */
 	private function get_video_thumbnail() {
+		$override = self::$override_thumbnail;
+		if ( is_array( $override ) && ! empty( $override['url'] ) ) {
+			return array(
+				'url'    => $override['url'],
+				'width'  => isset( $override['width'] ) ? (int) $override['width'] : 0,
+				'height' => isset( $override['height'] ) ? (int) $override['height'] : 0,
+			);
+		}
+
 		$thumbnail_sizes = array( 'tainacan-medium', 'medium_large', 'medium', 'large', 'full' );
 		$item = self::$override_item;
-
 		if ( is_object( $item ) && is_callable( array( $item, 'get_thumbnail' ) ) ) {
 			$thumbnails = $item->get_thumbnail();
 			if ( is_array( $thumbnails ) ) {
@@ -249,6 +273,158 @@ class Embed {
 	}
 
 	/**
+	 * Finds an image attachment that pairs with a video attachment by sharing
+	 * the same file name (minus extension).
+	 *
+	 * Content managers can upload e.g. interview.mp4 together with interview.jpg
+	 * so the video lazyload placeholder shows a real miniature instead of the
+	 * generic video icon.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param int $attachment_id Video attachment ID.
+	 * @return array|null Thumbnail URL and dimensions, or null when no image is paired.
+	 */
+	public function get_video_companion_thumbnail( $attachment_id ) {
+		$attachment_id = (int) $attachment_id;
+		$attachment = $attachment_id ? get_post( $attachment_id ) : null;
+
+		if (
+			! $attachment instanceof \WP_Post
+			|| ! wp_attachment_is( 'video', $attachment )
+			|| empty( $attachment->post_parent )
+		) {
+			return null;
+		}
+
+		$file = get_attached_file( $attachment_id );
+		$file_name = $file ? pathinfo( $file, PATHINFO_FILENAME ) : '';
+		if ( '' === $file_name ) {
+			return null;
+		}
+
+		$siblings = get_posts( array(
+			'post_type'      => 'attachment',
+			'post_parent'    => (int) $attachment->post_parent,
+			'post_mime_type' => 'image',
+			'posts_per_page' => -1,
+			'exclude'        => array( $attachment_id ),
+		) );
+
+		foreach ( $siblings as $sibling ) {
+			$sibling_file = get_attached_file( $sibling->ID );
+			$sibling_name = $sibling_file ? pathinfo( $sibling_file, PATHINFO_FILENAME ) : '';
+
+			if ( '' !== $sibling_name && 0 === strcasecmp( $file_name, $sibling_name ) ) {
+				foreach ( array( 'tainacan-medium', 'medium_large', 'medium', 'large', 'full' ) as $size ) {
+					$src = wp_get_attachment_image_src( $sibling->ID, $size );
+					if ( is_array( $src ) ) {
+						return array(
+							'url'    => $src[0],
+							'width'  => (int) $src[1],
+							'height' => (int) $src[2],
+						);
+					}
+				}
+
+				// No generated image sizes: fall back to the original file URL.
+				$url = wp_get_attachment_url( $sibling->ID );
+				if ( $url ) {
+					return array(
+						'url'    => $url,
+						'width'  => 0,
+						'height' => 0,
+					);
+				}
+
+				return null;
+			}
+		}
+
+		return null;
+	}
+
+	/**
+	 * Removes image attachments that serve as miniatures for sibling videos
+	 * from item attachment lists.
+	 *
+	 * When an image pairs with a non-document video of the same item, it is
+	 * displayed inside the video placeholder and showing it again in the
+	 * gallery would duplicate the content. The document video is excluded from
+	 * the pairing because it always uses the item's own thumbnail.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param array                          $attachments List of attachment posts.
+	 * @param \Tainacan\Entities\Item|null   $item        Owning item.
+	 * @return array Filtered attachment list.
+	 */
+	public function filter_video_companion_images( $attachments, $item = null ) {
+		if ( ! is_array( $attachments ) || empty( $attachments ) || ! $this->is_video_lazyload_enabled() ) {
+			return $attachments;
+		}
+
+		$item_id = 0;
+		if ( is_object( $item ) && method_exists( $item, 'get_id' ) && (int) $item->get_id() ) {
+			$item_id = (int) $item->get_id();
+		} elseif ( ! empty( $attachments[0] ) && $attachments[0] instanceof \WP_Post && $attachments[0]->post_parent ) {
+			$item_id = (int) $attachments[0]->post_parent;
+		}
+		if ( ! $item_id ) {
+			return $attachments;
+		}
+
+		$excluded_ids = array();
+		if (
+			is_object( $item )
+			&& method_exists( $item, 'get_document_type' )
+			&& method_exists( $item, 'get_document' )
+			&& $item->get_document_type() === 'attachment'
+			&& (int) $item->get_document()
+		) {
+			$excluded_ids[] = (int) $item->get_document();
+		}
+
+		$videos = get_posts( array(
+			'post_type'      => 'attachment',
+			'post_parent'    => $item_id,
+			'post_mime_type' => 'video',
+			'posts_per_page' => -1,
+			'exclude'        => $excluded_ids,
+			'fields'         => 'ids',
+		) );
+		if ( empty( $videos ) ) {
+			return $attachments;
+		}
+
+		$video_names = array();
+		foreach ( $videos as $video_id ) {
+			$file = get_attached_file( $video_id );
+			$name = $file ? pathinfo( $file, PATHINFO_FILENAME ) : '';
+			if ( '' !== $name ) {
+				$video_names[ mb_strtolower( $name ) ] = true;
+			}
+		}
+		if ( empty( $video_names ) ) {
+			return $attachments;
+		}
+
+		$result = array();
+		foreach ( $attachments as $attachment ) {
+			if ( $attachment instanceof \WP_Post && wp_attachment_is( 'image', $attachment ) ) {
+				$file = get_attached_file( $attachment->ID );
+				$name = $file ? pathinfo( $file, PATHINFO_FILENAME ) : '';
+				if ( '' !== $name && isset( $video_names[ mb_strtolower( $name ) ] ) ) {
+					continue;
+				}
+			}
+			$result[] = $attachment;
+		}
+
+		return $result;
+	}
+
+	/**
 	 * Runs WordPress autoembed on a URL while applying Tainacan's custom
 	 * video/audio markup.
 	 *
@@ -260,34 +436,35 @@ class Embed {
 	 *
 	 * @since 1.0.0
 	 *
-	 * @param string      $url  The URL to embed.
-	 * @param object|null $item The Tainacan item owning the embed.
+	 * @param string      $url       The URL to embed.
+	 * @param object|null $item      The Tainacan item owning the embed.
+	 * @param array|null  $thumbnail Explicit thumbnail (url/width/height) taking
+	 *                                precedence over the item thumbnail.
 	 * @return string The embed HTML, or the original URL when autoembed fails.
 	 */
-	public function embed( $url, $item = null ) {
+	public function embed( $url, $item = null, $thumbnail = null ) {
 		global $wp_embed;
 
 		$previous_override_active = self::$override_active;
 		$previous_override_item = self::$override_item;
+		$previous_override_thumbnail = self::$override_thumbnail;
 		self::$override_active = true;
 		self::$override_item = $item;
+		self::$override_thumbnail = is_array( $thumbnail ) && ! empty( $thumbnail['url'] ) ? $thumbnail : null;
 
 		try {
 			return $wp_embed->autoembed( $url );
 		} finally {
 			self::$override_active = $previous_override_active;
 			self::$override_item = $previous_override_item;
+			self::$override_thumbnail = $previous_override_thumbnail;
 		}
 	}
-
 	/**
 	 * Handles PDF file embedding using iframe.
 	 *
 	 * @since 0.1.0
 	 *
-	 * @param array  $matches   Regex matches from the embed handler.
-	 * @param array  $attr      Embed attributes.
-	 * @param string $url       The PDF file URL.
 	 * @param array  $rawattr   Raw embed attributes.
 	 * @return string PDF embed HTML.
 	 */

--- a/src/classes/media-helper/class-tainacan-embed.php
+++ b/src/classes/media-helper/class-tainacan-embed.php
@@ -108,6 +108,10 @@ class Embed {
 			return $video;
 		}
 
+		if ( ! $this->is_video_lazyload_enabled() ) {
+			return $this->get_video_embed( $attr, $url );
+		}
+
 		$thumbnail = $this->get_video_thumbnail();
 		$video_dimensions = '';
 		if ( ! empty( $attr['width'] ) ) {
@@ -170,6 +174,39 @@ class Embed {
 		
 	}
 	
+	/**
+	 * Checks whether video lazyload is enabled in Tainacan settings.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @return bool Whether video placeholders should be rendered.
+	 */
+	private function is_video_lazyload_enabled() {
+		return rest_sanitize_boolean( get_option( 'tainacan_option_enable_video_lazyload', true ) );
+	}
+
+	/**
+	 * Renders the scoped video output when lazyload is disabled.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param array  $attr Video attributes.
+	 * @param string $url  Video URL.
+	 * @return string Video HTML.
+	 */
+	private function get_video_embed( $attr, $url ) {
+		$dimensions = '';
+		if ( ! empty( $attr['width'] ) && ! empty( $attr['height'] ) ) {
+			$dimensions = sprintf( 'width="%d" ', absint( $attr['width'] ) );
+		}
+
+		return sprintf(
+			'<video controls="" preload="none" %s src="%s"></video>',
+			$dimensions,
+			esc_url( $url )
+		);
+	}
+
 	/**
 	 * Gets the thumbnail to display before a Tainacan video is activated.
 	 *

--- a/src/classes/media-helper/class-tainacan-embed.php
+++ b/src/classes/media-helper/class-tainacan-embed.php
@@ -283,9 +283,9 @@ class Embed {
 	 * @since 1.0.0
 	 *
 	 * @param int $attachment_id Video attachment ID.
-	 * @return array|null Thumbnail URL and dimensions, or null when no image is paired.
+	 * @return int|null Paired image attachment ID, or null when none is found.
 	 */
-	public function get_video_companion_thumbnail( $attachment_id ) {
+	public function get_video_companion_attachment_id( $attachment_id ) {
 		$attachment_id = (int) $attachment_id;
 		$attachment = $attachment_id ? get_post( $attachment_id ) : null;
 
@@ -316,29 +316,46 @@ class Embed {
 			$sibling_name = $sibling_file ? pathinfo( $sibling_file, PATHINFO_FILENAME ) : '';
 
 			if ( '' !== $sibling_name && 0 === strcasecmp( $file_name, $sibling_name ) ) {
-				foreach ( array( 'tainacan-medium', 'medium_large', 'medium', 'large', 'full' ) as $size ) {
-					$src = wp_get_attachment_image_src( $sibling->ID, $size );
-					if ( is_array( $src ) ) {
-						return array(
-							'url'    => $src[0],
-							'width'  => (int) $src[1],
-							'height' => (int) $src[2],
-						);
-					}
-				}
-
-				// No generated image sizes: fall back to the original file URL.
-				$url = wp_get_attachment_url( $sibling->ID );
-				if ( $url ) {
-					return array(
-						'url'    => $url,
-						'width'  => 0,
-						'height' => 0,
-					);
-				}
-
-				return null;
+				return (int) $sibling->ID;
 			}
+		}
+
+		return null;
+	}
+
+	/**
+	 * Resolves the thumbnail of a video's paired image attachment.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param int $attachment_id Video attachment ID.
+	 * @return array|null Thumbnail URL and dimensions, or null when no image is paired.
+	 */
+	public function get_video_companion_thumbnail( $attachment_id ) {
+		$sibling_id = $this->get_video_companion_attachment_id( $attachment_id );
+		if ( ! $sibling_id ) {
+			return null;
+		}
+
+		foreach ( array( 'tainacan-medium', 'medium_large', 'medium', 'large', 'full' ) as $size ) {
+			$src = wp_get_attachment_image_src( $sibling_id, $size );
+			if ( is_array( $src ) ) {
+				return array(
+					'url'    => $src[0],
+					'width'  => (int) $src[1],
+					'height' => (int) $src[2],
+				);
+			}
+		}
+
+		// No generated image sizes: fall back to the original file URL.
+		$url = wp_get_attachment_url( $sibling_id );
+		if ( $url ) {
+			return array(
+				'url'    => $url,
+				'width'  => 0,
+				'height' => 0,
+			);
 		}
 
 		return null;

--- a/src/classes/media-helper/class-tainacan-embed.php
+++ b/src/classes/media-helper/class-tainacan-embed.php
@@ -16,6 +16,29 @@ class Embed {
 	use \Tainacan\Traits\Singleton_Instance;
 
 	/**
+	 * Whether Tainacan's custom video/audio markup should be applied to the
+	 * current autoembed() call.
+	 *
+	 * The wp_embed_handler_video/audio filters are registered once at plugin
+	 * load, but they must only take effect when Tainacan itself is embedding
+	 * media (Tainacan admin item pages, item single pages, the media page and
+	 * the URL metadata type). This flag is toggled by Embed::embed() so the
+	 * override never leaks into unrelated WordPress content.
+	 *
+	 * @since 1.0.0
+	 * @var bool
+	 */
+	private static $override_active = false;
+
+	/**
+	 * Item currently being embedded by Tainacan.
+	 *
+	 * @since 1.0.0
+	 * @var object|null
+	 */
+	private static $override_item = null;
+
+	/**
 	 * Available aspect ratios for responsive embeds.
 	 *
 	 * @since 0.1.0
@@ -48,7 +71,7 @@ class Embed {
 	protected function init() {
 		
 		/**
-		 * Replace default WordPress embedders with HTML 5 tags instead of shortcodes
+		 * Replace default WordPress embedders with Tainacan media markup.
 		 */
 		add_filter('wp_embed_handler_video', [$this, 'filter_video_embed'], 10, 4);
 		add_filter('wp_embed_handler_audio', [$this, 'filter_audio_embed'], 10, 4);
@@ -76,19 +99,46 @@ class Embed {
 	 * @param array  $attr     Embed attributes.
 	 * @param string $url      The video URL.
 	 * @param array  $rawattr  Raw embed attributes.
-	 * @return string Modified video embed HTML.
+	 * @return string Placeholder HTML for a Tainacan video embed.
 	 */
 	public function filter_video_embed($video, $attr, $url, $rawattr) {
 		
-		
-		$dimensions = '';
-		if ( ! empty( $attr['width'] ) && ! empty( $attr['height'] ) ) {
-			$dimensions .= sprintf( 'width="%d" ', (int) $attr['width'] );
-			//$dimensions .= sprintf( 'height="%d" ', (int) $attr['height'] );
+		// Only apply Tainacan's video markup while Tainacan is embedding its own content.
+		if ( ! self::$override_active ) {
+			return $video;
 		}
-		$video = sprintf( '<video controls="" %s src="%s"></video>', $dimensions, esc_url( $url ) );
-		
-		return $video;
+
+		$thumbnail = $this->get_video_thumbnail();
+		$video_dimensions = '';
+		if ( ! empty( $attr['width'] ) ) {
+			$video_width = absint( $attr['width'] );
+			if ( $video_width ) {
+				$video_dimensions .= sprintf( ' data-video-width="%d"', $video_width );
+			}
+		}
+		if ( ! empty( $attr['height'] ) ) {
+			$video_height = absint( $attr['height'] );
+			if ( $video_height ) {
+				$video_dimensions .= sprintf( ' data-video-height="%d"', $video_height );
+			}
+		}
+
+		$image_dimensions = '';
+		if ( ! empty( $thumbnail['width'] ) ) {
+			$image_dimensions .= sprintf( ' width="%d"', absint( $thumbnail['width'] ) );
+		}
+		if ( ! empty( $thumbnail['height'] ) ) {
+			$image_dimensions .= sprintf( ' height="%d"', absint( $thumbnail['height'] ) );
+		}
+
+		return sprintf(
+			'<a class="tainacan-video-lazyload" href="%1$s" data-video-src="%1$s"%2$s aria-label="%3$s"><img src="%4$s"%5$s alt=""><span class="tainacan-video-lazyload__play" aria-hidden="true"></span></a>',
+			esc_url( $url ),
+			$video_dimensions,
+			esc_attr__( 'Play video', 'tainacan' ),
+			esc_url( $thumbnail['url'] ),
+			$image_dimensions
+		);
 		
 	}
 	
@@ -105,6 +155,11 @@ class Embed {
 	 */
 	public function filter_audio_embed($audio, $attr, $url, $rawattr) {
 		
+		// Only apply Tainacan's audio markup while Tainacan is embedding its own content.
+		if ( ! self::$override_active ) {
+			return $audio;
+		}
+		
 		if ( ! empty( $attr['width'] ) ) {
 			$dimensions = sprintf( 'width="%d" ', (int) $attr['width'] );
 		}
@@ -115,6 +170,79 @@ class Embed {
 		
 	}
 	
+	/**
+	 * Gets the thumbnail to display before a Tainacan video is activated.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @return array Thumbnail URL and dimensions.
+	 */
+	private function get_video_thumbnail() {
+		$thumbnail_sizes = array( 'tainacan-medium', 'medium_large', 'medium', 'large', 'full' );
+		$item = self::$override_item;
+
+		if ( is_object( $item ) && is_callable( array( $item, 'get_thumbnail' ) ) ) {
+			$thumbnails = $item->get_thumbnail();
+			if ( is_array( $thumbnails ) ) {
+				foreach ( $thumbnail_sizes as $size ) {
+					if ( ! empty( $thumbnails[ $size ] ) && is_array( $thumbnails[ $size ] ) && ! empty( $thumbnails[ $size ][0] ) ) {
+						return array(
+							'url'    => $thumbnails[ $size ][0],
+							'width'  => isset( $thumbnails[ $size ][1] ) ? $thumbnails[ $size ][1] : 0,
+							'height' => isset( $thumbnails[ $size ][2] ) ? $thumbnails[ $size ][2] : 0,
+						);
+					}
+				}
+			}
+		}
+
+		$placeholder = function_exists( 'tainacan_get_the_mime_type_icon' )
+			? tainacan_get_the_mime_type_icon( 'video', 'medium' )
+			: '';
+		if ( empty( $placeholder ) ) {
+			global $TAINACAN_BASE_URL;
+			$placeholder = trailingslashit( $TAINACAN_BASE_URL ) . 'assets/images/placeholder_video_medium.png';
+		}
+
+		return array(
+			'url'    => $placeholder,
+			'width'  => 0,
+			'height' => 0,
+		);
+	}
+
+	/**
+	 * Runs WordPress autoembed on a URL while applying Tainacan's custom
+	 * video/audio markup.
+	 *
+	 * WordPress processes media URLs in content through the registered embed
+	 * handlers. Tainacan's own markup must only be produced for media that
+	 * Tainacan itself embeds (item documents, attachments, URL metadata and
+	 * the media page), never for unrelated WordPress content. This wrapper
+	 * scopes the override to exactly those calls.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param string      $url  The URL to embed.
+	 * @param object|null $item The Tainacan item owning the embed.
+	 * @return string The embed HTML, or the original URL when autoembed fails.
+	 */
+	public function embed( $url, $item = null ) {
+		global $wp_embed;
+
+		$previous_override_active = self::$override_active;
+		$previous_override_item = self::$override_item;
+		self::$override_active = true;
+		self::$override_item = $item;
+
+		try {
+			return $wp_embed->autoembed( $url );
+		} finally {
+			self::$override_active = $previous_override_active;
+			self::$override_item = $previous_override_item;
+		}
+	}
+
 	/**
 	 * Handles PDF file embedding using iframe.
 	 *
@@ -262,7 +390,57 @@ class Embed {
 		}
 		:not(.wp-block-embed__wrapper)>.tainacan-embed-aspect-1-2 .tainacan-content-embed__wrapper::before {
 			padding-top: 200%; /* 2 / 1 * 100 */
-		}';
+		}
+		.tainacan-video-lazyload {
+			position: relative;
+			display: block;
+			width: 100%;
+			max-width: 100%;
+			background: #000;
+			cursor: pointer;
+			text-decoration: none;
+		}
+		.tainacan-video-lazyload img {
+			display: block;
+			width: 100%;
+			height: auto;
+			max-width: 100%;
+		}
+		.tainacan-video-lazyload__play {
+			position: absolute;
+			top: 50%;
+			left: 50%;
+			width: 3.5rem;
+			height: 3.5rem;
+			border-radius: 50%;
+			background: rgba(0, 0, 0, 0.7);
+			transform: translate(-50%, -50%);
+		}
+		.tainacan-video-lazyload__play::before {
+			content: "";
+			position: absolute;
+			top: 50%;
+			left: 50%;
+			border-top: 0.65rem solid transparent;
+			border-bottom: 0.65rem solid transparent;
+			border-left: 1rem solid #fff;
+			transform: translate(-35%, -50%);
+		}
+		.tainacan-video-lazyload:hover .tainacan-video-lazyload__play,
+		.tainacan-video-lazyload:focus .tainacan-video-lazyload__play {
+			background: rgba(0, 0, 0, 0.9);
+		}
+		.tainacan-video-lazyload:focus {
+			outline: 2px solid currentColor;
+			outline-offset: 3px;
+		}
+		.tainacan-video-lazyload__video {
+			display: block;
+			width: 100%;
+			height: auto;
+			max-width: 100%;
+		}
+		';
 	}
 
 	/**

--- a/src/classes/media-helper/class-tainacan-embed.php
+++ b/src/classes/media-helper/class-tainacan-embed.php
@@ -39,6 +39,16 @@ class Embed {
 	private static $override_item = null;
 
 	/**
+	 * Lazyload decision for the current autoembed() call. When set, takes
+	 * precedence over the lazyload setting — used by contexts where the
+	 * lazyload script cannot run, like the bare attachment media page.
+	 *
+	 * @since 1.0.0
+	 * @var bool|null
+	 */
+	private static $override_lazyload = null;
+
+	/**
 	 * Explicit thumbnail for the current autoembed() call, taking precedence
 	 * over the item thumbnail (e.g. an image attachment paired with a video
 	 * file by sharing the same file name).
@@ -124,7 +134,7 @@ class Embed {
 			return $video;
 		}
 
-		if ( ! $this->is_video_lazyload_enabled() ) {
+		if ( ! ( null !== self::$override_lazyload ? self::$override_lazyload : $this->is_video_lazyload_enabled() ) ) {
 			return $this->get_video_embed( $attr, $url );
 		}
 
@@ -457,17 +467,21 @@ class Embed {
 	 * @param object|null $item      The Tainacan item owning the embed.
 	 * @param array|null  $thumbnail Explicit thumbnail (url/width/height) taking
 	 *                                precedence over the item thumbnail.
+	 * @param bool|null   $lazyload  Forces lazyload placeholders on or off for
+	 *                                this call, bypassing the setting.
 	 * @return string The embed HTML, or the original URL when autoembed fails.
 	 */
-	public function embed( $url, $item = null, $thumbnail = null ) {
+	public function embed( $url, $item = null, $thumbnail = null, $lazyload = null ) {
 		global $wp_embed;
 
 		$previous_override_active = self::$override_active;
 		$previous_override_item = self::$override_item;
 		$previous_override_thumbnail = self::$override_thumbnail;
+		$previous_override_lazyload = self::$override_lazyload;
 		self::$override_active = true;
 		self::$override_item = $item;
 		self::$override_thumbnail = is_array( $thumbnail ) && ! empty( $thumbnail['url'] ) ? $thumbnail : null;
+		self::$override_lazyload = $lazyload;
 
 		try {
 			return $wp_embed->autoembed( $url );
@@ -475,6 +489,7 @@ class Embed {
 			self::$override_active = $previous_override_active;
 			self::$override_item = $previous_override_item;
 			self::$override_thumbnail = $previous_override_thumbnail;
+			self::$override_lazyload = $previous_override_lazyload;
 		}
 	}
 	/**

--- a/src/classes/media-helper/class-tainacan-embed.php
+++ b/src/classes/media-helper/class-tainacan-embed.php
@@ -405,6 +405,8 @@ class Embed {
 			width: 100%;
 			height: auto;
 			max-width: 100%;
+			object-fit: contain;
+			aspect-ratio: 16 / 9;
 		}
 		.tainacan-video-lazyload__play {
 			position: absolute;

--- a/src/classes/media-helper/class-tainacan-embed.php
+++ b/src/classes/media-helper/class-tainacan-embed.php
@@ -201,7 +201,7 @@ class Embed {
 		}
 
 		return sprintf(
-			'<video controls="" preload="none" %s src="%s"></video>',
+			'<video class="tainacan-video-embed" controls="" preload="none" playsinline="" %s src="%s"></video>',
 			$dimensions,
 			esc_url( $url )
 		);
@@ -427,6 +427,16 @@ class Embed {
 		}
 		:not(.wp-block-embed__wrapper)>.tainacan-embed-aspect-1-2 .tainacan-content-embed__wrapper::before {
 			padding-top: 200%; /* 2 / 1 * 100 */
+		}
+		.tainacan-video-embed {
+			display: block;
+			width: 100%;
+			height: auto;
+			max-width: 100%;
+			aspect-ratio: 16 / 9;
+			object-fit: contain;
+			background: #000;
+			pointer-events: auto;
 		}
 		.tainacan-video-lazyload {
 			position: relative;

--- a/src/classes/media-helper/class-tainacan-media.php
+++ b/src/classes/media-helper/class-tainacan-media.php
@@ -755,7 +755,9 @@ class Media {
 			if ( ! $is_main_document && wp_attachment_is( 'video', $att_id ) ) {
 				$companion_thumbnail = $tainacan_embed->get_video_companion_thumbnail( $att_id );
 			}
-			$embed = $tainacan_embed->embed( $url, $item, $companion_thumbnail );
+			// The bare attachment page prints no scripts: lazyload placeholders
+			// could never be activated there, so render the native video.
+			$embed = $tainacan_embed->embed( $url, $item, $companion_thumbnail, false );
 
 			if ( esc_url($embed) == esc_url($url) ) {
 				$output .= sprintf("<a href='%s' target='blank'>%s</a>", $url, $url);

--- a/src/classes/media-helper/class-tainacan-media.php
+++ b/src/classes/media-helper/class-tainacan-media.php
@@ -750,7 +750,8 @@ class Media {
 			$url = wp_get_attachment_url($att_id);
 
 			$tainacan_embed = \Tainacan\Embed::get_instance();
-			$embed = $tainacan_embed->embed( $url, $item );
+			$is_main_document = $item->get_document_type() === 'attachment' && (int) $item->get_document() === (int) $att_id;
+			$embed = $tainacan_embed->embed( $url, $is_main_document ? $item : null );
 
 			if ( esc_url($embed) == esc_url($url) ) {
 				$output .= sprintf("<a href='%s' target='blank'>%s</a>", $url, $url);

--- a/src/classes/media-helper/class-tainacan-media.php
+++ b/src/classes/media-helper/class-tainacan-media.php
@@ -751,7 +751,11 @@ class Media {
 
 			$tainacan_embed = \Tainacan\Embed::get_instance();
 			$is_main_document = $item->get_document_type() === 'attachment' && (int) $item->get_document() === (int) $att_id;
-			$embed = $tainacan_embed->embed( $url, $is_main_document ? $item : null );
+			$companion_thumbnail = null;
+			if ( ! $is_main_document && wp_attachment_is( 'video', $att_id ) ) {
+				$companion_thumbnail = $tainacan_embed->get_video_companion_thumbnail( $att_id );
+			}
+			$embed = $tainacan_embed->embed( $url, $item, $companion_thumbnail );
 
 			if ( esc_url($embed) == esc_url($url) ) {
 				$output .= sprintf("<a href='%s' target='blank'>%s</a>", $url, $url);

--- a/src/classes/media-helper/class-tainacan-media.php
+++ b/src/classes/media-helper/class-tainacan-media.php
@@ -746,11 +746,11 @@ class Media {
 		} else {
 			$this->add_css();
 			wp_print_styles('tainacan-media-page');
-			global $wp_embed;
 
 			$url = wp_get_attachment_url($att_id);
 
-			$embed = $wp_embed->autoembed($url);
+			$tainacan_embed = \Tainacan\Embed::get_instance();
+			$embed = $tainacan_embed->embed( $url, $item );
 
 			if ( esc_url($embed) == esc_url($url) ) {
 				$output .= sprintf("<a href='%s' target='blank'>%s</a>", $url, $url);

--- a/src/classes/theme-helper/class-tainacan-theme-helper.php
+++ b/src/classes/theme-helper/class-tainacan-theme-helper.php
@@ -2211,6 +2211,18 @@ class Theme_Helper {
 			if ( $media_sources['attachments'] ) {
 				foreach ( $attachments as $attachment ) {
 					$attachment_thumbnail = get_the_post_thumbnail($attachment->ID, $thumbnails_size);
+
+					// Videos display the miniature chosen for them (a paired image
+					// attachment, then the item thumbnail) instead of the generic icon.
+					if ( ! $attachment_thumbnail && wp_attachment_is('video', $attachment->ID) ) {
+						$companion_id = \Tainacan\Embed::get_instance()->get_video_companion_attachment_id($attachment->ID);
+
+						if ( $companion_id )
+							$attachment_thumbnail = wp_get_attachment_image($companion_id, $thumbnails_size, false);
+
+						if ( ! $attachment_thumbnail )
+							$attachment_thumbnail = get_the_post_thumbnail($item_id, $thumbnails_size);
+					}
 					$media_items_thumbnails[] = 
 						tainacan_get_the_media_component_slide(array(
 							'media_content' => $attachment_thumbnail ? $attachment_thumbnail : wp_get_attachment_image( $attachment->ID, $thumbnails_size, false ),

--- a/src/views/admin/components/edition/item-document-edition-form.vue
+++ b/src/views/admin/components/edition/item-document-edition-form.vue
@@ -196,6 +196,11 @@ export default {
                 width: auto !important;
                 margin: 0;
             }
+            :deep(.tainacan-video-lazyload img) {
+                width: 100% !important;
+                object-fit: contain;
+                aspect-ratio: 16 / 9;
+            }
             :deep(a) {
                 min-height: 60px;
                 display: block;

--- a/src/views/admin/components/metadata-types/url/class-tainacan-url.php
+++ b/src/views/admin/components/metadata-types/url/class-tainacan-url.php
@@ -68,7 +68,6 @@ class URL extends Metadata_Type {
 	public function get_value_as_html(\Tainacan\Entities\Item_Metadata_Entity $item_metadata) {
 		
 		$value = $item_metadata->get_value();
-		$item = $item_metadata->get_item();
 		$link_as_button = $this->get_option('link-as-button') == 'yes';
 		$return = '';
 
@@ -80,7 +79,7 @@ class URL extends Metadata_Type {
 				$list_items = [];
 				foreach ( $value as $el ) {
 					if ( !empty($el) ) {
-						$list_items[] = $this->get_single_value_as_html($el, $item);
+						$list_items[] = $this->get_single_value_as_html($el);
 					}
 				}
 				$total = count( $list_items );
@@ -102,7 +101,7 @@ class URL extends Metadata_Type {
 				foreach ( $value as $el ) {
 					if ( !empty($el) ) {
 						$return .= $prefix;
-						$return .= $this->get_single_value_as_html($el, $item);
+						$return .= $this->get_single_value_as_html($el);
 						$return .= $suffix;
 						$count++;
 						if ( $count < $total && !$link_as_button ) {
@@ -112,7 +111,7 @@ class URL extends Metadata_Type {
 				}
 			}
 		} else {			
-			$return .= $this->get_single_value_as_html($value, $item);
+			$return .= $this->get_single_value_as_html($value);
 		}
 		$return .= $link_as_button ? '</div>' : '';
 
@@ -132,7 +131,7 @@ class URL extends Metadata_Type {
 	 * Get the a single value as a HTML string with links
 	 * @return string
 	 */
-	public function get_single_value_as_html($value, $item = null) {
+	public function get_single_value_as_html($value) {
 
 		$link_as_button = $this->get_option('link-as-button') == 'yes';
 		$return = '';
@@ -148,7 +147,7 @@ class URL extends Metadata_Type {
 
 			// First, we try WordPress autoembed
 			$tainacan_embed = \Tainacan\Embed::get_instance();
-			$embed = $tainacan_embed->embed( $value, $item );
+			$embed = $tainacan_embed->embed( $value );
 			
 			// If it didn't work, it will still ba a URL
  			if ( esc_url($embed) == esc_url($value) ) {

--- a/src/views/admin/components/metadata-types/url/class-tainacan-url.php
+++ b/src/views/admin/components/metadata-types/url/class-tainacan-url.php
@@ -68,6 +68,7 @@ class URL extends Metadata_Type {
 	public function get_value_as_html(\Tainacan\Entities\Item_Metadata_Entity $item_metadata) {
 		
 		$value = $item_metadata->get_value();
+		$item = $item_metadata->get_item();
 		$link_as_button = $this->get_option('link-as-button') == 'yes';
 		$return = '';
 
@@ -79,7 +80,7 @@ class URL extends Metadata_Type {
 				$list_items = [];
 				foreach ( $value as $el ) {
 					if ( !empty($el) ) {
-						$list_items[] = $this->get_single_value_as_html($el);
+						$list_items[] = $this->get_single_value_as_html($el, $item);
 					}
 				}
 				$total = count( $list_items );
@@ -87,8 +88,8 @@ class URL extends Metadata_Type {
 					$return .= $list_items[0];
 				} elseif ( $total > 1 ) {
 					$return .= '<ul>';
-					foreach ( $list_items as $item ) {
-						$return .= '<li>' . $item . '</li>';
+					foreach ( $list_items as $list_item ) {
+						$return .= '<li>' . $list_item . '</li>';
 					}
 					$return .= '</ul>';
 				}
@@ -101,7 +102,7 @@ class URL extends Metadata_Type {
 				foreach ( $value as $el ) {
 					if ( !empty($el) ) {
 						$return .= $prefix;
-						$return .= $this->get_single_value_as_html($el);
+						$return .= $this->get_single_value_as_html($el, $item);
 						$return .= $suffix;
 						$count++;
 						if ( $count < $total && !$link_as_button ) {
@@ -111,7 +112,7 @@ class URL extends Metadata_Type {
 				}
 			}
 		} else {			
-			$return .= $this->get_single_value_as_html($value);	
+			$return .= $this->get_single_value_as_html($value, $item);
 		}
 		$return .= $link_as_button ? '</div>' : '';
 
@@ -131,8 +132,7 @@ class URL extends Metadata_Type {
 	 * Get the a single value as a HTML string with links
 	 * @return string
 	 */
-	public function get_single_value_as_html($value) {
-		global $wp_embed;
+	public function get_single_value_as_html($value, $item = null) {
 
 		$link_as_button = $this->get_option('link-as-button') == 'yes';
 		$return = '';
@@ -147,7 +147,8 @@ class URL extends Metadata_Type {
 		} else {
 
 			// First, we try WordPress autoembed
-			$embed = $wp_embed->autoembed($value);
+			$tainacan_embed = \Tainacan\Embed::get_instance();
+			$embed = $tainacan_embed->embed( $value, $item );
 			
 			// If it didn't work, it will still ba a URL
  			if ( esc_url($embed) == esc_url($value) ) {

--- a/src/views/admin/pages/singles/item-page.vue
+++ b/src/views/admin/pages/singles/item-page.vue
@@ -1079,6 +1079,11 @@
             :deep(img) {
                 width: auto !important;
             }
+            :deep(.tainacan-video-lazyload img) {
+                width: 100% !important;
+                object-fit: contain;
+                aspect-ratio: 16 / 9;
+            }
             :deep(a) {
                 min-height: 60px;
                 display: block;

--- a/src/views/gutenberg-blocks/blocks/item-gallery/style.scss
+++ b/src/views/gutenberg-blocks/blocks/item-gallery/style.scss
@@ -140,6 +140,10 @@
             audio {
                 pointer-events: none;
             }
+            .tainacan-video-lazyload__video {
+                pointer-events: auto;
+                cursor: auto;
+            }
             a {
                 cursor: zoom-in !important;
             }

--- a/src/views/gutenberg-blocks/blocks/item-gallery/style.scss
+++ b/src/views/gutenberg-blocks/blocks/item-gallery/style.scss
@@ -304,6 +304,11 @@
             max-width: 100%;
             height: auto;
         }
+        .tainacan-video-lazyload img {
+            width: 100%;
+            object-fit: contain;
+            aspect-ratio: 16 / 9;
+        }
         .twitter-tweet {
             margin-left: auto;
             margin-right: auto;

--- a/src/views/gutenberg-blocks/blocks/item-gallery/style.scss
+++ b/src/views/gutenberg-blocks/blocks/item-gallery/style.scss
@@ -304,7 +304,7 @@
             max-width: 100%;
             height: auto;
         }
-        .tainacan-video-lazyload {
+        & > a.tainacan-video-lazyload {
             z-index: auto;
         }
         .tainacan-video-lazyload img {

--- a/src/views/gutenberg-blocks/blocks/item-gallery/style.scss
+++ b/src/views/gutenberg-blocks/blocks/item-gallery/style.scss
@@ -140,7 +140,8 @@
             audio {
                 pointer-events: none;
             }
-            .tainacan-video-lazyload__video {
+            .tainacan-video-lazyload__video,
+            video.tainacan-video-embed {
                 pointer-events: auto;
                 cursor: auto;
             }
@@ -301,6 +302,14 @@
             width: 100%;
             height: auto;
             max-height: var(--tainacan-media-main-carousel-height, 60vh);
+        }
+        video.tainacan-video-embed {
+            width: 100%;
+            height: auto;
+            max-height: none;
+            aspect-ratio: 16 / 9;
+            object-fit: contain;
+            background-color: #000;
         }
         img {
             width: auto;
@@ -696,6 +705,15 @@
         video {
             min-height: 56px;
             max-width: 80%;
+        }
+        video.tainacan-video-embed {
+            width: 100%;
+            max-width: 100%;
+            height: auto;
+            aspect-ratio: 16 / 9;
+            object-fit: contain;
+            background-color: #000;
+            pointer-events: auto;
         }
         iframe {
             border: none;

--- a/src/views/gutenberg-blocks/blocks/item-gallery/style.scss
+++ b/src/views/gutenberg-blocks/blocks/item-gallery/style.scss
@@ -304,6 +304,9 @@
             max-width: 100%;
             height: auto;
         }
+        .tainacan-video-lazyload {
+            z-index: auto;
+        }
         .tainacan-video-lazyload img {
             width: 100%;
             object-fit: contain;

--- a/src/views/gutenberg-blocks/tainacan-blocks-common-scripts.js
+++ b/src/views/gutenberg-blocks/tainacan-blocks-common-scripts.js
@@ -1,4 +1,5 @@
 import * as conditioner from 'conditioner-core/conditioner-core.esm';
+import '../tainacan-video-lazyload.js';
 const { __ } = wp.i18n;
 
 // Updates Webpack public path based on plugin folder URL, using variable obtained from server side.

--- a/src/views/settings/class-tainacan-settings.php
+++ b/src/views/settings/class-tainacan-settings.php
@@ -171,6 +171,18 @@ class Settings extends Pages {
 				: null
 		) );
 
+		$this->create_tainacan_setting( array(
+			'id' => 'enable_video_lazyload',
+			'section' => 'tainacan_settings_search_and_performance',
+			'title' => __( 'Enable video lazyload', 'tainacan' ),
+			'label' => __( 'Enable video lazyloading will add a placeholder image instead of the video.', 'tainacan' ),
+			'description' => __( 'When enabled, videos are initially replaced with a placeholder and loaded only after the visitor activates them. The item thumbnail is used only as the placeholder for the main document video; attached videos and video URLs use Tainacan\'s default video placeholder.', 'tainacan' ),
+			'type' => 'boolean',
+			'input_type' => 'checkbox',
+			'sanitize_callback' => 'rest_sanitize_boolean',
+			'default' => true
+		) );
+
 		/**
 		 * Theme default templates -----------------------------------------------------
 		 */

--- a/src/views/settings/class-tainacan-settings.php
+++ b/src/views/settings/class-tainacan-settings.php
@@ -176,7 +176,7 @@ class Settings extends Pages {
 			'section' => 'tainacan_settings_search_and_performance',
 			'title' => __( 'Enable video lazyload', 'tainacan' ),
 			'label' => __( 'Enable video lazyloading will add a placeholder image instead of the video.', 'tainacan' ),
-			'description' => __( 'When enabled, videos are initially replaced with a placeholder and loaded only after the visitor activates them. The item thumbnail is used only as the placeholder for the main document video; attached videos and video URLs use Tainacan\'s default video placeholder.', 'tainacan' ),
+			'description' => __( 'When enabled, videos are initially replaced with a placeholder and loaded only after the visitor activates them. The placeholder image is chosen in this order: an image attachment whose file name matches the video file name (except for the main document video, which always uses the item thumbnail), then the item thumbnail — so multiple videos may repeat the same image — and, if neither exists, Tainacan\'s default video placeholder.', 'tainacan' ),
 			'type' => 'boolean',
 			'input_type' => 'checkbox',
 			'sanitize_callback' => 'rest_sanitize_boolean',

--- a/src/views/tainacan-pages-common-scripts.js
+++ b/src/views/tainacan-pages-common-scripts.js
@@ -1,4 +1,5 @@
 import * as conditioner from 'conditioner-core/conditioner-core.esm';
+import './tainacan-video-lazyload.js';
 const { __ } = wp.i18n;
 
 // Updates Webpack public path based on plugin folder URL, using variable obtained from server side.

--- a/src/views/tainacan-video-lazyload.js
+++ b/src/views/tainacan-video-lazyload.js
@@ -1,0 +1,64 @@
+const activateLazyVideo = (placeholder) => {
+    if (!placeholder || !placeholder.parentNode)
+        return;
+
+    const videoSrc = placeholder.getAttribute('data-video-src');
+    if (!videoSrc)
+        return;
+
+    const video = document.createElement('video');
+    video.className = 'tainacan-video-lazyload__video';
+    video.setAttribute('controls', 'controls');
+    video.setAttribute('preload', 'none');
+    video.setAttribute('playsinline', 'playsinline');
+    video.setAttribute('autoplay', 'autoplay');
+    video.src = videoSrc;
+
+    ['width', 'height'].forEach((dimension) => {
+        const value = placeholder.getAttribute(`data-video-${dimension}`);
+        if (value && /^[1-9][0-9]*$/.test(value))
+            video.setAttribute(dimension, value);
+    });
+
+    placeholder.parentNode.replaceChild(video, placeholder);
+
+    try {
+        const playback = video.play();
+        if (playback && typeof playback.catch === 'function')
+            playback.catch(() => {});
+    } catch {
+        // The controls remain available if the browser rejects immediate playback.
+    }
+};
+
+const handleLazyVideoActivation = (event) => {
+    const target = event.target;
+    if (!target || typeof target.closest !== 'function')
+        return;
+
+    const placeholder = target.closest('.tainacan-video-lazyload');
+    if (!placeholder)
+        return;
+
+    if (event.type === 'keydown' && event.key !== 'Enter' && event.key !== ' ') {
+        return;
+    }
+
+    event.preventDefault();
+    event.stopPropagation();
+    activateLazyVideo(placeholder);
+};
+
+const initializeLazyVideos = () => {
+    document.addEventListener('click', handleLazyVideoActivation, true);
+    document.addEventListener('keydown', handleLazyVideoActivation, true);
+};
+
+if (typeof document !== 'undefined') {
+    if (/comp|inter|loaded/.test(document.readyState))
+        initializeLazyVideos();
+    else
+        document.addEventListener('DOMContentLoaded', initializeLazyVideos, false);
+}
+
+export { activateLazyVideo, handleLazyVideoActivation, initializeLazyVideos };

--- a/src/views/tainacan-video-lazyload.js
+++ b/src/views/tainacan-video-lazyload.js
@@ -14,10 +14,19 @@ const activateLazyVideo = (placeholder) => {
     video.setAttribute('autoplay', 'autoplay');
     video.src = videoSrc;
 
+    ['click', 'pointerdown', 'touchstart'].forEach((eventType) => {
+        video.addEventListener(eventType, (event) => event.stopPropagation());
+    });
+
     ['width', 'height'].forEach((dimension) => {
         const value = placeholder.getAttribute(`data-video-${dimension}`);
         if (value && /^[1-9][0-9]*$/.test(value))
             video.setAttribute(dimension, value);
+    });
+
+    document.querySelectorAll('.tainacan-video-lazyload__video').forEach((activeVideo) => {
+        if (activeVideo !== video && typeof activeVideo.pause === 'function')
+            activeVideo.pause();
     });
 
     placeholder.parentNode.replaceChild(video, placeholder);

--- a/src/views/tainacan-video-lazyload.js
+++ b/src/views/tainacan-video-lazyload.js
@@ -1,3 +1,15 @@
+const stopVideoInteractionPropagation = (event) => event.stopPropagation();
+
+const attachVideoInteractionListeners = (video) => {
+    ['click', 'pointerdown', 'touchstart'].forEach((eventType) => {
+        video.addEventListener(eventType, stopVideoInteractionPropagation);
+    });
+};
+
+const initializeVideoEmbeds = () => {
+    document.querySelectorAll('video.tainacan-video-embed').forEach(attachVideoInteractionListeners);
+};
+
 const activateLazyVideo = (placeholder) => {
     if (!placeholder || !placeholder.parentNode)
         return;
@@ -14,9 +26,7 @@ const activateLazyVideo = (placeholder) => {
     video.setAttribute('autoplay', 'autoplay');
     video.src = videoSrc;
 
-    ['click', 'pointerdown', 'touchstart'].forEach((eventType) => {
-        video.addEventListener(eventType, (event) => event.stopPropagation());
-    });
+    attachVideoInteractionListeners(video);
 
     ['width', 'height'].forEach((dimension) => {
         const value = placeholder.getAttribute(`data-video-${dimension}`);
@@ -61,6 +71,7 @@ const handleLazyVideoActivation = (event) => {
 const initializeLazyVideos = () => {
     document.addEventListener('click', handleLazyVideoActivation, true);
     document.addEventListener('keydown', handleLazyVideoActivation, true);
+    initializeVideoEmbeds();
 };
 
 if (typeof document !== 'undefined') {
@@ -70,4 +81,4 @@ if (typeof document !== 'undefined') {
         document.addEventListener('DOMContentLoaded', initializeLazyVideos, false);
 }
 
-export { activateLazyVideo, handleLazyVideoActivation, initializeLazyVideos };
+export { activateLazyVideo, handleLazyVideoActivation, initializeLazyVideos, initializeVideoEmbeds };

--- a/tests/test-video-embed.php
+++ b/tests/test-video-embed.php
@@ -83,6 +83,46 @@ class VideoEmbed extends TAINACAN_UnitTestCase {
 	}
 
 	/**
+	 * Item thumbnails must be reserved for the main document.
+	 */
+	public function test_attached_video_uses_default_placeholder() {
+		$item = new class extends \Tainacan\Entities\Item {
+			public function get_thumbnail() {
+				return array(
+					'tainacan-medium' => array(
+						'https://example.com/item-thumbnail.jpg',
+						275,
+						275,
+						false,
+						''
+					),
+				);
+			}
+		};
+		$attachment_id = wp_insert_attachment(
+			array(
+				'post_title'     => 'Attached video',
+				'post_status'    => 'inherit',
+				'post_mime_type' => 'video/mp4',
+				'guid'           => 'https://example.com/attached-video.mp4',
+			)
+		);
+
+		try {
+			$attachment_output = $item->get_attachment_as_html($attachment_id);
+			$this->assertStringContainsString('placeholder_video', $attachment_output);
+			$this->assertStringNotContainsString('item-thumbnail.jpg', $attachment_output);
+
+			$item->set_document_type('attachment');
+			$item->set_document($attachment_id);
+			$document_output = $item->get_document_as_html();
+			$this->assertStringContainsString('item-thumbnail.jpg', $document_output);
+		} finally {
+			wp_delete_attachment($attachment_id, true);
+		}
+	}
+
+	/**
 	 * Runs the Embed wrapper with a small stand-in for WP_Embed.
 	 *
 	 * @param string $url  Video URL.

--- a/tests/test-video-embed.php
+++ b/tests/test-video-embed.php
@@ -1,0 +1,113 @@
+<?php
+
+namespace Tainacan\Tests;
+
+/**
+ * Tests Tainacan's scoped video embed output.
+ */
+class VideoEmbed extends TAINACAN_UnitTestCase {
+
+	/**
+	 * WordPress output must pass through when Tainacan is not embedding it.
+	 */
+	public function test_video_embed_is_unchanged_outside_tainacan_context() {
+		$default_video = '<video class="wp-default" src="https://example.com/video.mp4"></video>';
+		$embed = \Tainacan\Embed::get_instance();
+
+		$this->assertSame(
+			$default_video,
+			$embed->filter_video_embed(
+				$default_video,
+				array(),
+				'https://example.com/video.mp4',
+				array()
+			)
+		);
+	}
+
+	/**
+	 * Tainacan embeds must return a placeholder rather than a video element.
+	 */
+	public function test_tainacan_video_embed_returns_lazy_placeholder() {
+		$item = new class {
+			public function get_thumbnail() {
+				return array(
+					'tainacan-medium' => array(
+						'https://example.com/item-thumbnail.jpg',
+						275,
+						275,
+						false,
+						''
+					),
+				);
+			}
+		};
+
+		$output = $this->run_tainacan_embed('https://example.com/video.mp4', $item);
+
+		$this->assertStringNotContainsString('<video', $output);
+		$this->assertStringContainsString('class="tainacan-video-lazyload"', $output);
+		$this->assertStringContainsString('data-video-src="https://example.com/video.mp4"', $output);
+		$this->assertStringContainsString('https://example.com/item-thumbnail.jpg', $output);
+
+		$default_video = '<video class="wp-default"></video>';
+		$this->assertSame(
+			$default_video,
+			\Tainacan\Embed::get_instance()->filter_video_embed(
+				$default_video,
+				array(),
+				'https://example.com/video.mp4',
+				array()
+			)
+		);
+	}
+
+	/**
+	 * A missing item thumbnail must use Tainacan's existing video placeholder.
+	 */
+	public function test_tainacan_video_embed_uses_video_placeholder_without_thumbnail() {
+		$item = new class {
+			public function get_thumbnail() {
+				return array(
+					'tainacan-medium' => false,
+					'medium_large' => false,
+				);
+			}
+		};
+
+		$output = $this->run_tainacan_embed('https://example.com/video.mp4', $item);
+
+		$this->assertStringNotContainsString('<video', $output);
+		$this->assertStringContainsString('placeholder_video', $output);
+		$this->assertStringContainsString('tainacan-video-lazyload__play', $output);
+	}
+
+	/**
+	 * Runs the Embed wrapper with a small stand-in for WP_Embed.
+	 *
+	 * @param string $url  Video URL.
+	 * @param object|null $item Owning item context.
+	 * @return string
+	 */
+	private function run_tainacan_embed($url, $item = null) {
+		global $wp_embed;
+
+		$previous_wp_embed = $wp_embed;
+		$wp_embed = new class {
+			public function autoembed($url) {
+				return \Tainacan\Embed::get_instance()->filter_video_embed(
+					'<video class="wp-default"></video>',
+					array('width' => 640),
+					$url,
+					array()
+				);
+			}
+		};
+
+		try {
+			return \Tainacan\Embed::get_instance()->embed($url, $item);
+		} finally {
+			$wp_embed = $previous_wp_embed;
+		}
+	}
+}

--- a/tests/test-video-embed.php
+++ b/tests/test-video-embed.php
@@ -93,6 +93,7 @@ class VideoEmbed extends TAINACAN_UnitTestCase {
 			$output = $this->run_tainacan_embed('https://example.com/video.mp4');
 
 			$this->assertStringContainsString('<video', $output);
+			$this->assertStringContainsString('class="tainacan-video-embed"', $output);
 			$this->assertStringContainsString('preload="none"', $output);
 			$this->assertStringNotContainsString('tainacan-video-lazyload', $output);
 		} finally {

--- a/tests/test-video-embed.php
+++ b/tests/test-video-embed.php
@@ -83,6 +83,24 @@ class VideoEmbed extends TAINACAN_UnitTestCase {
 	}
 
 	/**
+	 * Lazyload can be disabled while retaining the scoped video output.
+	 */
+	public function test_video_lazyload_can_be_disabled() {
+		update_option( 'tainacan_option_enable_video_lazyload', '0' );
+
+		try {
+			$this->assertSame( '0', get_option( 'tainacan_option_enable_video_lazyload', true ) );
+			$output = $this->run_tainacan_embed('https://example.com/video.mp4');
+
+			$this->assertStringContainsString('<video', $output);
+			$this->assertStringContainsString('preload="none"', $output);
+			$this->assertStringNotContainsString('tainacan-video-lazyload', $output);
+		} finally {
+			delete_option( 'tainacan_option_enable_video_lazyload' );
+		}
+	}
+
+	/**
 	 * Item thumbnails must be reserved for the main document.
 	 */
 	public function test_attached_video_uses_default_placeholder() {

--- a/tests/test-video-embed.php
+++ b/tests/test-video-embed.php
@@ -102,9 +102,10 @@ class VideoEmbed extends TAINACAN_UnitTestCase {
 	}
 
 	/**
-	 * Item thumbnails must be reserved for the main document.
+	 * Without a companion image, non-document videos fall back to the item
+	 * thumbnail instead of the generic placeholder.
 	 */
-	public function test_attached_video_uses_default_placeholder() {
+	public function test_attached_video_without_companion_uses_item_thumbnail() {
 		$item = new class extends \Tainacan\Entities\Item {
 			public function get_thumbnail() {
 				return array(
@@ -129,8 +130,9 @@ class VideoEmbed extends TAINACAN_UnitTestCase {
 
 		try {
 			$attachment_output = $item->get_attachment_as_html($attachment_id);
-			$this->assertStringContainsString('placeholder_video', $attachment_output);
-			$this->assertStringNotContainsString('item-thumbnail.jpg', $attachment_output);
+			$this->assertStringContainsString('class="tainacan-video-lazyload"', $attachment_output);
+			$this->assertStringContainsString('item-thumbnail.jpg', $attachment_output);
+			$this->assertStringNotContainsString('placeholder_video', $attachment_output);
 
 			$item->set_document_type('attachment');
 			$item->set_document($attachment_id);
@@ -138,6 +140,116 @@ class VideoEmbed extends TAINACAN_UnitTestCase {
 			$this->assertStringContainsString('item-thumbnail.jpg', $document_output);
 		} finally {
 			wp_delete_attachment($attachment_id, true);
+		}
+	}
+
+	/**
+	 * A non-document video attachment must use a same-named image attachment
+	 * as its lazyload miniature.
+	 */
+	public function test_attached_video_uses_companion_image_as_miniature() {
+		$item = new class extends \Tainacan\Entities\Item {
+			public function get_thumbnail() {
+				return array(
+					'tainacan-medium' => array(
+						'https://example.com/item-thumbnail.jpg',
+						275,
+						275,
+						false,
+						''
+					),
+				);
+			}
+		};
+		$video_id = wp_insert_attachment(
+			array(
+				'post_title'     => 'Interview video',
+				'post_status'    => 'inherit',
+				'post_mime_type' => 'video/mp4',
+				'guid'           => 'https://example.com/interview.mp4',
+			),
+			'/tmp/interview.mp4'
+		);
+		$image_id = wp_insert_attachment(
+			array(
+				'post_title'     => 'Interview miniature',
+				'post_status'    => 'inherit',
+				'post_mime_type' => 'image/jpeg',
+				'guid'           => 'https://example.com/interview.jpg',
+			),
+			'/tmp/interview.jpg',
+			$item->get_id()
+		);
+
+		try {
+			$output = $item->get_attachment_as_html($video_id);
+
+			$this->assertStringContainsString('class="tainacan-video-lazyload"', $output);
+			$this->assertStringContainsString('interview.jpg', $output);
+			$this->assertStringNotContainsString('placeholder_video', $output);
+			$this->assertStringNotContainsString('item-thumbnail.jpg', $output);
+		} finally {
+			wp_delete_attachment($video_id, true);
+			wp_delete_attachment($image_id, true);
+		}
+	}
+
+	/**
+	 * Images paired with non-document videos must not be listed as gallery
+	 * attachments, while pairs of the document video stay visible.
+	 */
+	public function test_companion_images_are_hidden_from_attachments_list() {
+		$item = new class extends \Tainacan\Entities\Item {
+			private $document;
+
+			public function set_document( $document ) {
+				$this->document = $document;
+			}
+
+			public function get_id() {
+				return 424242;
+			}
+
+			public function get_document_type() {
+				return $this->document ? 'attachment' : 'url';
+			}
+
+			public function get_document() {
+				return $this->document;
+			}
+		};
+		$make_attachment = function ( $title, $mime, $guid, $file ) use ( $item ) {
+			return wp_insert_attachment(
+				array(
+					'post_title'     => $title,
+					'post_status'    => 'inherit',
+					'post_mime_type' => $mime,
+					'guid'           => $guid,
+					'post_parent'    => $item->get_id(),
+				),
+				$file
+			);
+		};
+		$video_id = $make_attachment('Second video', 'video/mp4', 'https://example.com/second.mp4', '/tmp/second.mp4');
+		$companion_id = $make_attachment('Second miniature', 'image/jpeg', 'https://example.com/second.jpg', '/tmp/second.jpg');
+		$unrelated_id = $make_attachment('Poster', 'image/png', 'https://example.com/poster.png', '/tmp/poster.png');
+		$attachments = array( get_post($companion_id), get_post($unrelated_id) );
+
+		$embed = \Tainacan\Embed::get_instance();
+
+		try {
+			// Without a document video, the paired image is hidden.
+			$filtered = $embed->filter_video_companion_images($attachments, $item);
+			$this->assertSame(array($unrelated_id), wp_list_pluck($filtered, 'ID'));
+
+			// The document video keeps using the item thumbnail: its pair stays.
+			$item->set_document($video_id);
+			$filtered = $embed->filter_video_companion_images($attachments, $item);
+			$this->assertSame(array($companion_id, $unrelated_id), wp_list_pluck($filtered, 'ID'));
+		} finally {
+			wp_delete_attachment($video_id, true);
+			wp_delete_attachment($companion_id, true);
+			wp_delete_attachment($unrelated_id, true);
 		}
 	}
 

--- a/tests/test-video-lazyload.js
+++ b/tests/test-video-lazyload.js
@@ -9,14 +9,26 @@ globalThis.document = {
     addEventListener(type, handler) {
         listeners[type] = handler;
     },
+    querySelectorAll(selector) {
+        assert.equal(selector, '.tainacan-video-lazyload__video');
+        return createdVideos;
+    },
     createElement(type) {
         assert.equal(type, 'video');
         const attributes = {};
+        const eventListeners = {};
         const video = {
             attributes,
+            eventListeners,
             src: '',
+            addEventListener(type, handler) {
+                eventListeners[type] = handler;
+            },
             setAttribute(name, value) {
                 attributes[name] = value;
+            },
+            pause() {
+                video.pauseCalled = true;
             },
             play() {
                 video.playCalled = true;
@@ -29,6 +41,10 @@ globalThis.document = {
 };
 
 const { activateLazyVideo } = await import('../src/views/tainacan-video-lazyload.js');
+
+test.beforeEach(() => {
+    createdVideos.length = 0;
+});
 
 test('activating a lazy video creates and plays one video element', async () => {
     const attributes = {
@@ -62,6 +78,40 @@ test('activating a lazy video creates and plays one video element', async () => 
     assert.equal(createdVideos[0].attributes.height, '360');
     assert.equal(createdVideos[0].playCalled, true);
     assert.equal(placeholder.parentNode.replacedVideo, createdVideos[0]);
+
+    ['click', 'pointerdown', 'touchstart'].forEach((eventType) => {
+        let propagationStopped = false;
+        let defaultPrevented = false;
+        createdVideos[0].eventListeners[eventType]({
+            preventDefault() {
+                defaultPrevented = true;
+            },
+            stopPropagation() {
+                propagationStopped = true;
+            }
+        });
+
+        assert.equal(propagationStopped, true);
+        assert.equal(defaultPrevented, false);
+    });
+});
+
+test('activating another lazy video pauses existing lazy-loaded videos', () => {
+    const createPlaceholder = (videoSrc) => ({
+        getAttribute(name) {
+            return name === 'data-video-src' ? videoSrc : null;
+        },
+        parentNode: {
+            replaceChild() {}
+        }
+    });
+
+    activateLazyVideo(createPlaceholder('https://example.com/video.mp4'));
+    const previousVideo = createdVideos[0];
+    activateLazyVideo(createPlaceholder('https://example.com/another-video.mp4'));
+
+    assert.equal(previousVideo.pauseCalled, true);
+    assert.equal(createdVideos[1].playCalled, true);
 });
 
 test('the module registers delegated DOM readiness handling', () => {

--- a/tests/test-video-lazyload.js
+++ b/tests/test-video-lazyload.js
@@ -1,0 +1,69 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+const listeners = {};
+const createdVideos = [];
+
+globalThis.document = {
+    readyState: 'loading',
+    addEventListener(type, handler) {
+        listeners[type] = handler;
+    },
+    createElement(type) {
+        assert.equal(type, 'video');
+        const attributes = {};
+        const video = {
+            attributes,
+            src: '',
+            setAttribute(name, value) {
+                attributes[name] = value;
+            },
+            play() {
+                video.playCalled = true;
+                return Promise.resolve();
+            }
+        };
+        createdVideos.push(video);
+        return video;
+    }
+};
+
+const { activateLazyVideo } = await import('../src/views/tainacan-video-lazyload.js');
+
+test('activating a lazy video creates and plays one video element', async () => {
+    const attributes = {
+        'data-video-src': 'https://example.com/video.mp4',
+        'data-video-width': '640',
+        'data-video-height': '360'
+    };
+    const placeholder = {
+        getAttribute(name) {
+            return attributes[name] || null;
+        },
+        parentNode: {
+            replaceChild(video, oldPlaceholder) {
+                this.replacedVideo = video;
+                this.replacedPlaceholder = oldPlaceholder;
+            }
+        }
+    };
+
+    activateLazyVideo(placeholder);
+    await Promise.resolve();
+
+    assert.equal(createdVideos.length, 1);
+    assert.equal(createdVideos[0].src, 'https://example.com/video.mp4');
+    assert.equal(createdVideos[0].className, 'tainacan-video-lazyload__video');
+    assert.equal(createdVideos[0].attributes.controls, 'controls');
+    assert.equal(createdVideos[0].attributes.preload, 'none');
+    assert.equal(createdVideos[0].attributes.playsinline, 'playsinline');
+    assert.equal(createdVideos[0].attributes.autoplay, 'autoplay');
+    assert.equal(createdVideos[0].attributes.width, '640');
+    assert.equal(createdVideos[0].attributes.height, '360');
+    assert.equal(createdVideos[0].playCalled, true);
+    assert.equal(placeholder.parentNode.replacedVideo, createdVideos[0]);
+});
+
+test('the module registers delegated DOM readiness handling', () => {
+    assert.equal(typeof listeners.DOMContentLoaded, 'function');
+});

--- a/tests/test-video-lazyload.js
+++ b/tests/test-video-lazyload.js
@@ -3,6 +3,7 @@ import test from 'node:test';
 
 const listeners = {};
 const createdVideos = [];
+const embeddedVideos = [];
 
 globalThis.document = {
     readyState: 'loading',
@@ -10,8 +11,11 @@ globalThis.document = {
         listeners[type] = handler;
     },
     querySelectorAll(selector) {
-        assert.equal(selector, '.tainacan-video-lazyload__video');
-        return createdVideos;
+        if (selector === '.tainacan-video-lazyload__video')
+            return createdVideos;
+        if (selector === 'video.tainacan-video-embed')
+            return embeddedVideos;
+        assert.fail(`Unexpected selector: ${selector}`);
     },
     createElement(type) {
         assert.equal(type, 'video');
@@ -40,10 +44,11 @@ globalThis.document = {
     }
 };
 
-const { activateLazyVideo } = await import('../src/views/tainacan-video-lazyload.js');
+const { activateLazyVideo, initializeVideoEmbeds } = await import('../src/views/tainacan-video-lazyload.js');
 
 test.beforeEach(() => {
     createdVideos.length = 0;
+    embeddedVideos.length = 0;
 });
 
 test('activating a lazy video creates and plays one video element', async () => {
@@ -83,6 +88,34 @@ test('activating a lazy video creates and plays one video element', async () => 
         let propagationStopped = false;
         let defaultPrevented = false;
         createdVideos[0].eventListeners[eventType]({
+            preventDefault() {
+                defaultPrevented = true;
+            },
+            stopPropagation() {
+                propagationStopped = true;
+            }
+        });
+
+        assert.equal(propagationStopped, true);
+        assert.equal(defaultPrevented, false);
+    });
+});
+
+test('existing Tainacan videos stop PhotoSwipe propagation without preventing controls', () => {
+    const eventListeners = {};
+    const video = {
+        addEventListener(type, handler) {
+            eventListeners[type] = handler;
+        }
+    };
+    embeddedVideos.push(video);
+
+    initializeVideoEmbeds();
+
+    ['click', 'pointerdown', 'touchstart'].forEach((eventType) => {
+        let propagationStopped = false;
+        let defaultPrevented = false;
+        eventListeners[eventType]({
             preventDefault() {
                 defaultPrevented = true;
             },


### PR DESCRIPTION
Closes #1129

## Summary

Video documents rendered by Tainacan now display a lazy placeholder (the item's thumbnail, or a styled placeholder when none exists) with a play button. No video data is loaded until the visitor clicks; the actual `<video>` element replaces the placeholder on demand, similar to YouTube's click-to-load embeds.

- New `tainacan-video-lazyload.js` front-end script handling placeholder rendering and click-to-play
- A video lazyload setting added under Tainacan settings
- Item thumbnails reserved for document videos; gallery/admin placeholder sizing and z-index fixes so download controls and lightbox interactions keep working

## Relation to #1093 / #1120

This branch was detached from the `preload=none` work in #1120: the scoped embed infrastructure it depends on was absorbed into the first commit here, so this PR is based directly on `develop`. Until one of the two PRs merges, they will show overlapping changes in the shared files (`class-tainacan-embed.php`, `class-tainacan-item.php`, `class-tainacan-media.php`, `class-tainacan-url.php`); whichever merges second should be rebased.

## Testing

- `node --test tests/test-video-lazyload.js` (4 tests, all passing)
- PHPUnit `tests/test-video-embed.php` covering scoped vs unscoped embed output
