### PR TITLE
fix: Creates a BroadcastChannel logic for selection in iframed admin lists

### DIFF
--- a/docs/react-selection-modules.md
+++ b/docs/react-selection-modules.md
@@ -9,6 +9,8 @@ These are the currently available ones:
 - `tainacan_single_item_metadatum_selection_modal`: A modal for performing a single metadatum value selection.
 - `tainacan_single_item_metadata_section_selection_modal`: A modal for performing a single metadata section value selection.
 
+If you already embed the admin items list in your own iframe, you do not need these React modules. Subscribe to the selection [BroadcastChannel](#using-your-own-iframe) instead of reading the iframe URL.
+
 ## Why Use Them?
 
 Building selection flows is a relatively easy task if you're familiar with our [REST API](https://redocly.github.io/redoc/?url=https://raw.githubusercontent.com/tainacan/tainacan/refs/heads/develop/docs/openapi.json). However, offering the user a powerful UI do select items or metadata can be challenging if you have a big range of metadata and items to filter. Our modal components reuse the Admin Faceted Search UI, which means you'll have filters, facets, pagination and sorting options ready for you. This is big win because it will take out the burden of caring about pagination and other performance challenges.
@@ -175,7 +177,9 @@ export default ItemSelectionToolbar;
 
 #### Items Phase
 
-The Items phase brings the Tainacan Admin UI embedded in an Iframe with [some special URL](#available-selection-mode-parameters) params set. This hides the entire Admin UI, making things cleaner and loading only the necessary content to filter the desired items. One important consequence of this is that users will only see items that they are authorized to, as well as metadata and filters.
+The Items phase brings the Tainacan Admin UI embedded in an iframe with [some special URL](#available-selection-mode-parameters) params set. This hides the entire Admin UI, making things cleaner and loading only the necessary content to filter the desired items. One important consequence of this is that users will only see items that they are authorized to, as well as metadata and filters.
+
+Do not read the iframe's `Location` or `contentWindow` from your plugin. WordPress 7.1 isolates the block editor in Chromium, so that access can throw a `SecurityError` even on the same origin. The modal already receives selection and search state from the iframe and exposes it through the callbacks below. If you embed the admin items UI in your own iframe instead of using these modules, see [Using your own iframe](#using-your-own-iframe).
 
 ##### Manual Selection Strategy
 - Shows an `<iframe>` with the collection's items in selection mode
@@ -186,7 +190,7 @@ The Items phase brings the Tainacan Admin UI embedded in an Iframe with [some sp
 ##### Search Query Strategy
 - Shows an `<iframe>` with the collection's items in search mode
 - Users can configure filters, search terms, and sorting
-- The final search URL is returned via `onApplySearchURL`
+- The current admin page URL (including the hash query) is returned via `onApplySearchURL`
 - This URL can be used to dynamically load items later
 
 > [!NOTE]
@@ -209,22 +213,25 @@ You can pre-select a collection and skip the collection selection phase:
 
 #### Handling Search URLs
 
-When using the search strategy, the returned URL contains all the search parameters:
+When using the search strategy, `onApplySearchURL` receives the iframe's full admin URL. Search filters live in the **hash**, not in `location.search`:
+
+```
+https://example.org/wp-admin/admin.php?itemsSearchSelectionMode=true&page=tainacan_admin#/collections/123/items/?search=keyword&orderby=title&order=asc
+```
+
+Store that string as-is if you only need to reopen the same search. To turn it into a REST list request, take the path after `#/collections`, as the Gutenberg items blocks do:
 
 ```jsx
 const handleSearchURL = (searchURL) => {
-    // searchURL will contain filters, search terms, sorting, etc.
-    // Example: /collections/123/items/?search=keyword&orderby=title&order=asc
-    
-    // Store this URL to recreate the same search later
     setStoredSearchURL(searchURL);
-    
-    // Or parse it to extract specific parameters
-    const url = new URL(searchURL);
-    const searchTerm = url.searchParams.get('search');
-    const orderBy = url.searchParams.get('orderby');
+
+    const hashPath = searchURL.split('#')[1] || '';
+    const endpoint = '/collection' + hashPath.split('/collections')[1];
+    // Example: /collection/123/items/?search=keyword&orderby=title&order=asc
 };
 ```
+
+`new URL(searchURL).searchParams` only sees `itemsSearchSelectionMode` and `page`. It will not contain `search`, `orderby`, or selected item IDs.
 
 ### Styling and Customization
 
@@ -303,6 +310,74 @@ These are the URL parameters you can check to customize different selection mode
 - `itemsSingleSelectionMode`
 - `itemsMultipleSelectionMode`
 - `itemsSearchSelectionMode`
+
+## Using your own iframe
+
+You can reuse the Tainacan admin items list without the React selection modals: load it in your own `<iframe>` with one of the [selection mode parameters](#available-selection-mode-parameters). The admin then publishes a selection snapshot whenever the user changes the checked items or the search.
+
+Do not listen to iframe URL changes or read `iframe.contentWindow.location`. Subscribe to the same [BroadcastChannel](https://developer.mozilla.org/en-US/docs/Web/API/BroadcastChannel) the Gutenberg modals use. The channel is origin-scoped, so your script and the iframe must share the same origin (typical when both run from `wp-admin`).
+
+The iframe `src` must include one of:
+
+- `itemsSingleSelectionMode=true` — one item
+- `itemsMultipleSelectionMode=true` — a list of item IDs
+- `itemsSearchSelectionMode=true` — a search URL (filters live in the hash)
+
+```
+https://example.org/wp-admin/admin.php?itemsMultipleSelectionMode=true&page=tainacan_admin#/collections/123/items/?status=publish
+```
+
+Each message looks like:
+
+```js
+{
+    source: 'tainacan-selection',
+    selectedItems: ['12', '34'], // item IDs, for manual selection
+    query: {},                   // current search query object
+    href: 'https://example.org/wp-admin/admin.php?itemsMultipleSelectionMode=true&page=tainacan_admin#/collections/123/items/?status=publish&orderby=date',
+    collectionId: '123'
+}
+```
+
+Cache the last snapshot and read it when the user confirms. Use `selectedItems` for a manual list of IDs. Use `href` when the iframe is in search mode: it is the full admin URL, including the hash where filters live. To turn that string into a REST list request, parse the hash as in [Handling Search URLs](#handling-search-urls).
+
+```js
+const TAINACAN_SELECTION_CHANNEL = 'tainacan-selection';
+const TAINACAN_SELECTION_SOURCE = 'tainacan-selection';
+
+let lastSelection = null;
+const channel = new BroadcastChannel(TAINACAN_SELECTION_CHANNEL);
+
+channel.onmessage = (event) => {
+    const data = event.data;
+    if (!data || data.source !== TAINACAN_SELECTION_SOURCE)
+        return;
+
+    lastSelection = {
+        selectedItems: Array.isArray(data.selectedItems) ? data.selectedItems.map(String) : [],
+        query: data.query && typeof data.query === 'object' ? data.query : {},
+        href: data.href ? String(data.href) : '',
+        collectionId: data.collectionId != null ? String(data.collectionId) : ''
+    };
+};
+
+function applySelection() {
+    if (!lastSelection)
+        return;
+
+    // Manual selection: lastSelection.selectedItems
+    // Search selection: lastSelection.href (parse the hash as in "Handling Search URLs")
+}
+
+function teardown() {
+    channel.close();
+}
+```
+
+Close the channel when your UI is destroyed so a leftover listener does not keep receiving snapshots from a closed iframe.
+
+> [!WARNING]
+> `BroadcastChannel` delivers every snapshot on that origin. If more than one selection iframe could be open, ignore messages whose `collectionId` (or `href`) does not match the iframe you are showing.
 
 ## Conclusion
 

--- a/src/views/admin/js/event-bus-search.js
+++ b/src/views/admin/js/event-bus-search.js
@@ -1,10 +1,12 @@
 import mitt from 'mitt';
+import { isIframeSelectionMode, broadcastSelectionState, toPlainItemIds } from './selection-bridge.js';
 
 export default {
 
     install(app) {
 
         const emitter = mitt();
+
         const bus = {
             collectionId: undefined,
             defaultOrder: 'ASC',
@@ -210,24 +212,46 @@ export default {
                 app.config.globalProperties.$store.dispatch('search/setAdminViewMode', adminViewMode);
                 this.updateURLQueries();  
             },
+            publishSelectionState(selectedItems) {
+                if (!isIframeSelectionMode(app))
+                    return;
+
+                let items = toPlainItemIds(selectedItems);
+                if (!items.length) {
+                    try {
+                        items = toPlainItemIds(
+                            app.config.globalProperties.$store.getters['search/getSelectedItems']
+                        );
+                    } catch (e) {
+                        items = [];
+                    }
+                }
+
+                let query = {};
+                try {
+                    query = JSON.parse(JSON.stringify(
+                        app.config.globalProperties.$store.getters['search/getPostQuery'] || {}
+                    ));
+                } catch (e) {
+                    query = {};
+                }
+
+                broadcastSelectionState({
+                    selectedItems: items,
+                    query: query,
+                    href: window.location.href,
+                    collectionId: this.collectionId
+                });
+            },
             async setSelectedItemsForIframe(selectedItems, singleSelection) {
 
                 if (singleSelection)
                     app.config.globalProperties.$store.dispatch('search/cleanSelectedItems');
 
                 app.config.globalProperties.$store.dispatch('search/setSelectedItems', selectedItems);
-
-                let currentSelectedItems = app.config.globalProperties.$store.getters['search/getSelectedItems'];
-
-                if (window.history.replaceState) {
-                    let searchParams = new URLSearchParams(window.location.search);
-                    searchParams.delete('selecteditems');
-                    for (let selectedItem of currentSelectedItems)
-                        searchParams.append('selecteditems', selectedItem);
-
-                    let newurl = window.location.protocol + "//" + window.location.host + window.location.pathname + '?' + searchParams.toString() + window.location.hash;
-                    window.history.pushState({path: newurl}, '', newurl);
-                }      
+                this.publishSelectionState(
+                    toPlainItemIds(app.config.globalProperties.$store.getters['search/getSelectedItems'])
+                );
             },
             cleanSelectedItems() {
                 app.config.globalProperties.$store.dispatch('search/cleanSelectedItems');
@@ -237,7 +261,12 @@ export default {
             },
             updateURLQueries() {
                 const newQueries = JSON.parse(JSON.stringify(app.config.globalProperties.$store.getters['search/getPostQuery']));
-                app.config.globalProperties.$router.replace({ path: app.config.globalProperties.$route.path, query: newQueries });
+                const navigation = app.config.globalProperties.$router.replace({ path: app.config.globalProperties.$route.path, query: newQueries });
+                if (navigation && typeof navigation.finally === 'function') {
+                    navigation.finally(() => this.publishSelectionState());
+                } else {
+                    this.publishSelectionState();
+                }
             },
             updateStoreFromURL() {
                 app.config.globalProperties.$store.dispatch('search/setPostQuery', JSON.parse(JSON.stringify(app.config.globalProperties.$route.query)));
@@ -295,6 +324,9 @@ export default {
             }
         }
         app.config.globalProperties.$eventBusSearch = bus;
+
+        if (isIframeSelectionMode(app))
+            bus.publishSelectionState();
 
         // Defines the global $eventBusSearchEmitter for handling events across different search components
         emitter.on('input', data => {

--- a/src/views/admin/js/selection-bridge.js
+++ b/src/views/admin/js/selection-bridge.js
@@ -1,0 +1,89 @@
+/**
+ * Broadcast selection state from the admin items UI to Selection Listeners.
+ *
+ * The Selection Listeners do not read the iframe's Location as we did previously (https://github.com/tainacan/tainacan/issues/1132).
+ * The child publishes a plain snapshot of the selection state and search query, instead of the iframe's URL.
+ *
+ * Keep source/channel strings in sync with
+ * gutenberg-blocks/js/selection/tainacan-selection-listener.js.
+ */
+export const TAINACAN_SELECTION_SOURCE = 'tainacan-selection';
+export const TAINACAN_SELECTION_CHANNEL = 'tainacan-selection';
+
+export function isIframeSelectionMode(app) {
+    if (typeof window !== 'undefined') {
+        const params = new URLSearchParams(window.location.search);
+        if (params.has('itemsSingleSelectionMode') || params.has('itemsMultipleSelectionMode') || params.has('itemsSearchSelectionMode'))
+            return true;
+    }
+
+    const options = app && app.config.globalProperties.$adminOptions;
+    return !!(options && (options.itemsSingleSelectionMode || options.itemsMultipleSelectionMode || options.itemsSearchSelectionMode));
+}
+
+export function toPlainItemIds(items) {
+    if (items == null || items === false)
+        return [];
+
+    let list;
+    try {
+        list = typeof items === 'string' ? [items] : Array.from(items);
+    } catch (error) {
+        return [];
+    }
+
+    const seen = {};
+    const result = [];
+    for (let i = 0; i < list.length; i++) {
+        const id = list[i] == null ? '' : String(list[i]);
+        if (id === '' || id === 'false' || id === 'undefined' || id === 'null')
+            continue;
+        if (seen[id])
+            continue;
+        seen[id] = true;
+        result.push(id);
+    }
+    return result;
+}
+
+function cloneQuery(query) {
+    try {
+        return JSON.parse(JSON.stringify(query || {}));
+    } catch (error) {
+        return {};
+    }
+}
+
+function openSelectionChannel() {
+    try {
+        if (typeof BroadcastChannel === 'undefined')
+            return null;
+        return new BroadcastChannel(TAINACAN_SELECTION_CHANNEL);
+    } catch (error) {
+        return null;
+    }
+}
+
+let selectionChannel;
+
+export function broadcastSelectionState(state) {
+    const payload = {
+        source: TAINACAN_SELECTION_SOURCE,
+        selectedItems: toPlainItemIds(state && state.selectedItems),
+        query: cloneQuery(state && state.query),
+        href: state && state.href ? String(state.href) : (typeof window !== 'undefined' ? window.location.href : ''),
+        collectionId: state && state.collectionId != null && state.collectionId !== '' ? String(state.collectionId) : ''
+    };
+
+    if (!selectionChannel)
+        selectionChannel = openSelectionChannel();
+
+    if (!selectionChannel)
+        return;
+
+    try {
+        selectionChannel.postMessage(payload);
+    } catch (error) {
+        // Vue proxies should already have been cloned; ignore clone failures.
+    }
+}

--- a/src/views/gutenberg-blocks/blocks/item-metadata-section/edit.js
+++ b/src/views/gutenberg-blocks/blocks/item-metadata-section/edit.js
@@ -31,15 +31,21 @@ export default function ({ attributes, setAttributes, isSelected, context }) {
         textAlign
     } = attributes;
 
+    const contextItemId = context && context['tainacan/itemId'] != null ? Number( context['tainacan/itemId'] ) : NaN;
+    const attributeItemId = Number( itemId );
+
     // When rendered inside item-metadata-sections, use parent's itemId from context so we stay in sync when parent's item selection changes (InnerBlocks template is only used on initial creation).
-    const effectiveItemId = ( dataSource === 'parent' && context && context['tainacan/itemId'] != null ) ? Number( context['tainacan/itemId'] ) : ( isNaN( itemId ) ? 0 : Number( itemId ) );
+    const effectiveItemId = ( dataSource === 'parent' && Number.isFinite( contextItemId ) && contextItemId > 0 )
+        ? contextItemId
+        : ( Number.isFinite( attributeItemId ) ? attributeItemId : 0 );
 
     // Keep attribute in sync when we use context, so this block provides the correct itemId to its inner blocks (e.g. item-metadata) via context.
     useEffect(() => {
-        if ( dataSource === 'parent' && context && context['tainacan/itemId'] != null && Number( context['tainacan/itemId'] ) !== ( isNaN( itemId ) ? 0 : Number( itemId ) ) ) {
-            setAttributes({ itemId: Number( context['tainacan/itemId'] ) });
-        }
-    }, [ dataSource, context, itemId ]);
+        if ( dataSource !== 'parent' || !Number.isFinite( contextItemId ) || contextItemId <= 0 )
+            return;
+        if ( contextItemId !== ( Number.isFinite( attributeItemId ) ? attributeItemId : 0 ) )
+            setAttributes({ itemId: contextItemId });
+    }, [ dataSource, contextItemId, attributeItemId ]);
 
     // Gets blocks props from hook
     const blockProps = useBlockProps( {

--- a/src/views/gutenberg-blocks/blocks/item-metadata-sections/edit.js
+++ b/src/views/gutenberg-blocks/blocks/item-metadata-sections/edit.js
@@ -166,7 +166,10 @@ export default function ({ attributes, setAttributes, isSelected }) {
                                 });
                             }}
                             onApplySelectedItem={ (selectedItemId) => {
-                                itemId = Number(selectedItemId);
+                                const nextItemId = Number(selectedItemId);
+                                if ( !Number.isFinite(nextItemId) || nextItemId <= 0 )
+                                    return;
+                                itemId = nextItemId;
                                 setAttributes({
                                     itemId: itemId,
                                     isModalOpen: false

--- a/src/views/gutenberg-blocks/blocks/item-metadata/edit.js
+++ b/src/views/gutenberg-blocks/blocks/item-metadata/edit.js
@@ -30,15 +30,21 @@ export default function ({ attributes, setAttributes, isSelected, context }) {
         textAlign
     } = attributes;
 
+    const contextItemId = context && context['tainacan/itemId'] != null ? Number( context['tainacan/itemId'] ) : NaN;
+    const attributeItemId = Number( itemId );
+
     // When rendered inside item-metadata-sections (or item-metadata-section), use ancestor's itemId from context so we stay in sync when parent's item selection changes (InnerBlocks template is only used on initial creation).
-    const effectiveItemId = ( dataSource === 'parent' && context && context['tainacan/itemId'] != null ) ? Number( context['tainacan/itemId'] ) : ( isNaN( itemId ) ? 0 : Number( itemId ) );
+    const effectiveItemId = ( dataSource === 'parent' && Number.isFinite( contextItemId ) && contextItemId > 0 )
+        ? contextItemId
+        : ( Number.isFinite( attributeItemId ) ? attributeItemId : 0 );
 
     // Keep attribute in sync when we use context, so this block provides the correct itemId to its inner blocks (e.g. item-metadatum) via context.
     useEffect(() => {
-        if ( dataSource === 'parent' && context && context['tainacan/itemId'] != null && Number( context['tainacan/itemId'] ) !== ( isNaN( itemId ) ? 0 : Number( itemId ) ) ) {
-            setAttributes({ itemId: Number( context['tainacan/itemId'] ) });
-        }
-    }, [ dataSource, context, itemId ]);
+        if ( dataSource !== 'parent' || !Number.isFinite( contextItemId ) || contextItemId <= 0 )
+            return;
+        if ( contextItemId !== ( Number.isFinite( attributeItemId ) ? attributeItemId : 0 ) )
+            setAttributes({ itemId: contextItemId });
+    }, [ dataSource, contextItemId, attributeItemId ]);
 
     // Gets blocks props from hook
     const blockProps = useBlockProps( {
@@ -251,7 +257,10 @@ export default function ({ attributes, setAttributes, isSelected, context }) {
                                 });
                             }}
                             onApplySelectedItem={ (selectedItemId) => {
-                                itemId = Number(selectedItemId);
+                                const nextItemId = Number(selectedItemId);
+                                if ( !Number.isFinite(nextItemId) || nextItemId <= 0 )
+                                    return;
+                                itemId = nextItemId;
                                 setAttributes({
                                     itemId: itemId,
                                     isModalOpen: false

--- a/src/views/gutenberg-blocks/js/selection/tainacan-multiple-item-selection-modal.js
+++ b/src/views/gutenberg-blocks/js/selection/tainacan-multiple-item-selection-modal.js
@@ -1,5 +1,6 @@
 import tainacanApi from '../axios.js';
 import axios from 'axios';
+import { subscribeSelectionState } from './tainacan-selection-listener.js';
 
 const { __ } = wp.i18n;
 
@@ -39,6 +40,7 @@ export default class TainacanMultipleItemSelectionModal extends React.Component 
             itemsPerPage: 12,
             loadStrategy: loadStrategy
         };
+        this.selectionState = null;
         
         // Bind events
         this.resetCollections = this.resetCollections.bind(this);
@@ -48,15 +50,27 @@ export default class TainacanMultipleItemSelectionModal extends React.Component 
         this.fetchCollection = this.fetchCollection.bind(this);
         this.applySelectedSearchURL = this.applySelectedSearchURL.bind(this);
         this.applySelectedItems = this.applySelectedItems.bind(this);
+        this.onSelectionState = this.onSelectionState.bind(this);
+    }
+
+    onSelectionState(state) {
+        this.selectionState = state;
     }
 
     componentDidMount() {
+        this.unsubscribeSelectionState = subscribeSelectionState(this.onSelectionState);
+
         if (this.props.existingCollectionId) {
             this.fetchCollection(this.props.existingCollectionId);
         } else {
             this.setState({ collectionPage: 1 });
             this.fetchModalCollections();
         }
+    }
+
+    componentWillUnmount() {
+        if (this.unsubscribeSelectionState)
+            this.unsubscribeSelectionState();
     }
 
     // COLLECTIONS RELATED --------------------------------------------------
@@ -123,6 +137,7 @@ export default class TainacanMultipleItemSelectionModal extends React.Component 
     }
 
     selectCollection(selectedCollectionId) {
+        this.selectionState = null;
         this.setState({
             collectionId: selectedCollectionId,
             searchURL: tainacan_blocks.admin_url + '?' + (this.props.loadStrategy == 'search' ? 'itemsSearchSelectionMode' : 'itemsMultipleSelectionMode') + '=true&page=tainacan_admin#/collections/' + selectedCollectionId + '/items/?status=publish'
@@ -174,25 +189,19 @@ export default class TainacanMultipleItemSelectionModal extends React.Component 
             });
     }
 
-    applySelectedSearchURL() {    
-        let iframe = document.getElementById("itemsFrame");
-        if (iframe) {
-            this.props.onApplySearchURL(iframe.contentWindow.location.href);
-        }
+    applySelectedSearchURL() {
+        if (this.selectionState && this.selectionState.href)
+            this.props.onApplySearchURL(this.selectionState.href);
     }
 
     applySelectedItems() {
-        let iframe = document.getElementById("itemsFrame");
-        if (iframe) {
-            let params = new URLSearchParams(iframe.contentWindow.location.search);
-            let selectedItems = params.getAll('selecteditems');
-            params.delete('selecteditems')
-            this.props.onApplySelectedItems(selectedItems);
-        }
+        if (this.selectionState && this.selectionState.selectedItems && this.selectionState.selectedItems.length)
+            this.props.onApplySelectedItems(this.selectionState.selectedItems);
     }
 
     resetCollections() {
 
+        this.selectionState = null;
         this.setState({
             collectionId: null,
             collectionPage: 1,

--- a/src/views/gutenberg-blocks/js/selection/tainacan-selection-listener.js
+++ b/src/views/gutenberg-blocks/js/selection/tainacan-selection-listener.js
@@ -1,0 +1,40 @@
+/**
+ * Receive selection snapshots published by the admin items iframe.
+ *
+ * Keep source/channel strings in sync with admin/js/selection-bridge.js.
+ */
+export const TAINACAN_SELECTION_SOURCE = 'tainacan-selection';
+export const TAINACAN_SELECTION_CHANNEL = 'tainacan-selection';
+
+function normalizeSelectionState(data) {
+    if (!data || data.source !== TAINACAN_SELECTION_SOURCE)
+        return null;
+
+    return {
+        selectedItems: Array.isArray(data.selectedItems) ? data.selectedItems.map(String) : [],
+        query: data.query && typeof data.query === 'object' ? data.query : {},
+        href: data.href ? String(data.href) : '',
+        collectionId: data.collectionId != null ? String(data.collectionId) : ''
+    };
+}
+
+export function subscribeSelectionState(onState) {
+    let channel = null;
+    try {
+        if (typeof BroadcastChannel !== 'undefined') {
+            channel = new BroadcastChannel(TAINACAN_SELECTION_CHANNEL);
+            channel.onmessage = (event) => {
+                const state = normalizeSelectionState(event.data);
+                if (state)
+                    onState(state);
+            };
+        }
+    } catch (error) {
+        channel = null;
+    }
+
+    return () => {
+        if (channel)
+            channel.close();
+    };
+}

--- a/src/views/gutenberg-blocks/js/selection/tainacan-single-item-metadata-section-selection-modal.js
+++ b/src/views/gutenberg-blocks/js/selection/tainacan-single-item-metadata-section-selection-modal.js
@@ -1,5 +1,6 @@
 import tainacanApi from '../axios.js';
 import axios from 'axios';
+import { subscribeSelectionState } from './tainacan-selection-listener.js';
 
 const { __ } = wp.i18n;
 
@@ -43,6 +44,7 @@ export default class TainacanSingleItemMetadataSectionSelectionModal extends Rea
             itemsPerPage: 12,
             templateMode: props.isTemplateMode || false
         };
+        this.selectionState = null;
         
         // Bind events
         this.resetCollections = this.resetCollections.bind(this);
@@ -57,9 +59,16 @@ export default class TainacanSingleItemMetadataSectionSelectionModal extends Rea
         this.fetchModalMetadataSections = this.fetchModalMetadataSections.bind(this);
         
         this.applySelectedMetadataSection = this.applySelectedMetadataSection.bind(this);
+        this.onSelectionState = this.onSelectionState.bind(this);
+    }
+
+    onSelectionState(state) {
+        this.selectionState = state;
     }
 
     componentDidMount() {
+        this.unsubscribeSelectionState = subscribeSelectionState(this.onSelectionState);
+
         const { existingCollectionId, existingItemId, isTemplateMode } = this.props;
 
         if (existingCollectionId && !isTemplateMode) {
@@ -76,6 +85,11 @@ export default class TainacanSingleItemMetadataSectionSelectionModal extends Rea
             this.setState({ collectionPage: 1 });
             this.fetchModalCollections();
         }
+    }
+
+    componentWillUnmount() {
+        if (this.unsubscribeSelectionState)
+            this.unsubscribeSelectionState();
     }
 
     // COLLECTIONS RELATED --------------------------------------------------
@@ -147,6 +161,7 @@ export default class TainacanSingleItemMetadataSectionSelectionModal extends Rea
     }
 
     selectCollection(selectedCollectionId) {
+        this.selectionState = null;
         this.setState({
             collectionId: selectedCollectionId,
             searchURL: tainacan_blocks.admin_url + '?itemsSingleSelectionMode=true&page=tainacan_admin#/collections/' + selectedCollectionId + '/items/?status=publish'
@@ -235,18 +250,13 @@ export default class TainacanSingleItemMetadataSectionSelectionModal extends Rea
 
 
     selectItem() {
-        let iframe = document.getElementById("itemsFrame");
-        if (iframe) {
-            let params = new URLSearchParams(iframe.contentWindow.location.search);
-            let selectedItems = params.getAll('selecteditems');
-            params.delete('selecteditems')
-            if (selectedItems[0]) {
-                this.setState({
-                    itemId: selectedItems[0]
-                });
-                this.props.onSelectItem(selectedItems[0]);
-                this.fetchModalMetadataSections(this.state.collectionId);
-            }
+        const selectedItemId = this.selectionState && this.selectionState.selectedItems && this.selectionState.selectedItems[0];
+        if (selectedItemId) {
+            this.setState({
+                itemId: selectedItemId
+            });
+            this.props.onSelectItem(selectedItemId);
+            this.fetchModalMetadataSections(this.state.collectionId);
         }
     }
 
@@ -261,6 +271,7 @@ export default class TainacanSingleItemMetadataSectionSelectionModal extends Rea
 
     resetCollections() {
 
+        this.selectionState = null;
         this.setState({
             collectionId: null,
             collectionPage: 1,
@@ -271,6 +282,7 @@ export default class TainacanSingleItemMetadataSectionSelectionModal extends Rea
 
     resetItem() {
 
+        this.selectionState = null;
         this.setState({
             itemId: null,
         });

--- a/src/views/gutenberg-blocks/js/selection/tainacan-single-item-metadatum-selection-modal.js
+++ b/src/views/gutenberg-blocks/js/selection/tainacan-single-item-metadatum-selection-modal.js
@@ -1,5 +1,6 @@
 import tainacanApi from '../axios.js';
 import axios from 'axios';
+import { subscribeSelectionState } from './tainacan-selection-listener.js';
 
 const { __ } = wp.i18n;
 
@@ -44,6 +45,7 @@ export default class TainacanSingleItemMetadatumSelectionModal extends React.Com
             itemsPerPage: 12,
             templateMode: props.isTemplateMode || false
         };
+        this.selectionState = null;
         
         // Bind events
         this.resetCollections = this.resetCollections.bind(this);
@@ -58,9 +60,16 @@ export default class TainacanSingleItemMetadatumSelectionModal extends React.Com
         this.fetchModalMetadata = this.fetchModalMetadata.bind(this);
         
         this.applySelectedMetadatum = this.applySelectedMetadatum.bind(this);
+        this.onSelectionState = this.onSelectionState.bind(this);
+    }
+
+    onSelectionState(state) {
+        this.selectionState = state;
     }
 
     componentDidMount() {
+        this.unsubscribeSelectionState = subscribeSelectionState(this.onSelectionState);
+
         const { existingCollectionId, existingItemId, isTemplateMode } = this.props;
 
         if (existingCollectionId && !isTemplateMode) {
@@ -77,6 +86,11 @@ export default class TainacanSingleItemMetadatumSelectionModal extends React.Com
             this.setState({ collectionPage: 1 });
             this.fetchModalCollections();
         }
+    }
+
+    componentWillUnmount() {
+        if (this.unsubscribeSelectionState)
+            this.unsubscribeSelectionState();
     }
 
     // COLLECTIONS RELATED --------------------------------------------------
@@ -146,6 +160,7 @@ export default class TainacanSingleItemMetadatumSelectionModal extends React.Com
     }
 
     selectCollection(selectedCollectionId) {
+        this.selectionState = null;
         this.setState({
             collectionId: selectedCollectionId,
             searchURL: tainacan_blocks.admin_url + '?itemsSingleSelectionMode=true&page=tainacan_admin#/collections/' + selectedCollectionId + '/items/?status=publish'
@@ -236,18 +251,13 @@ export default class TainacanSingleItemMetadatumSelectionModal extends React.Com
 
 
     selectItem() {
-        let iframe = document.getElementById("itemsFrame");
-        if (iframe) {
-            let params = new URLSearchParams(iframe.contentWindow.location.search);
-            let selectedItems = params.getAll('selecteditems');
-            params.delete('selecteditems')
-            if (selectedItems[0]) {
-                this.setState({
-                    itemId: selectedItems[0]
-                });
-                this.props.onSelectItem(selectedItems[0]);
-                this.fetchModalMetadata(this.state.collectionId);
-            }
+        const selectedItemId = this.selectionState && this.selectionState.selectedItems && this.selectionState.selectedItems[0];
+        if (selectedItemId) {
+            this.setState({
+                itemId: selectedItemId
+            });
+            this.props.onSelectItem(selectedItemId);
+            this.fetchModalMetadata(this.state.collectionId);
         }
     }
 
@@ -264,6 +274,7 @@ export default class TainacanSingleItemMetadatumSelectionModal extends React.Com
 
     resetCollections() {
 
+        this.selectionState = null;
         this.setState({
             collectionId: null,
             collectionPage: 1,
@@ -274,6 +285,7 @@ export default class TainacanSingleItemMetadatumSelectionModal extends React.Com
 
     resetItem() {
 
+        this.selectionState = null;
         this.setState({
             itemId: null,
         });

--- a/src/views/gutenberg-blocks/js/selection/tainacan-single-item-selection-modal.js
+++ b/src/views/gutenberg-blocks/js/selection/tainacan-single-item-selection-modal.js
@@ -1,5 +1,6 @@
 import tainacanApi from '../axios.js';
 import axios from 'axios';
+import { subscribeSelectionState } from './tainacan-selection-listener.js';
 
 const { __ } = wp.i18n;
 
@@ -34,6 +35,7 @@ export default class TainacanSingleItemSelectionModal extends React.Component {
             searchURL: searchURL,
             itemsPerPage: 12
         };
+        this.selectionState = null;
         
         // Bind events
         this.resetCollections = this.resetCollections.bind(this);
@@ -42,15 +44,27 @@ export default class TainacanSingleItemSelectionModal extends React.Component {
         this.fetchModalCollections = this.fetchModalCollections.bind(this);
         this.fetchCollection = this.fetchCollection.bind(this);
         this.applySelectedItem = this.applySelectedItem.bind(this);
+        this.onSelectionState = this.onSelectionState.bind(this);
+    }
+
+    onSelectionState(state) {
+        this.selectionState = state;
     }
 
     componentDidMount() {
+        this.unsubscribeSelectionState = subscribeSelectionState(this.onSelectionState);
+
         if (this.props.existingCollectionId) {
             this.fetchCollection(this.props.existingCollectionId);
         } else {
             this.setState({ collectionPage: 1 });
             this.fetchModalCollections();
         }
+    }
+
+    componentWillUnmount() {
+        if (this.unsubscribeSelectionState)
+            this.unsubscribeSelectionState();
     }
 
     // COLLECTIONS RELATED --------------------------------------------------
@@ -111,6 +125,7 @@ export default class TainacanSingleItemSelectionModal extends React.Component {
     }
 
     selectCollection(selectedCollectionId) {
+        this.selectionState = null;
         this.setState({
             collectionId: selectedCollectionId,
             searchURL: tainacan_blocks.admin_url + '?itemsSingleSelectionMode=true&page=tainacan_admin#/collections/' + selectedCollectionId + '/items/?status=publish'
@@ -164,17 +179,14 @@ export default class TainacanSingleItemSelectionModal extends React.Component {
     }
 
     applySelectedItem() {
-        let iframe = document.getElementById("itemsFrame");
-        if (iframe) {
-            let params = new URLSearchParams(iframe.contentWindow.location.search);
-            let selectedItems = params.getAll('selecteditems');
-            params.delete('selecteditems')
-            this.props.onApplySelectedItem(selectedItems[0]);
-        }
+        const selectedItemId = this.selectionState && this.selectionState.selectedItems && this.selectionState.selectedItems[0];
+        if (selectedItemId)
+            this.props.onApplySelectedItem(selectedItemId);
     }
 
     resetCollections() {
 
+        this.selectionState = null;
         this.setState({
             collectionId: null,
             collectionPage: 1,


### PR DESCRIPTION
## Description

On WordPress 7.1, Chromium applies Document-Isolation-Policy to the (now always iframed) block editor. Gutenberg selection modals used to read the nested Tainacan admin iframe with `iframe.contentWindow.location.search`. That throws:

`SecurityError: Failed to read a named property 'search' from 'Location'`

Firefox still worked. Apply never received the selected item, so blocks such as Item Metadata Sections failed after **Show metadata sections for this item**. The same path is shared by all item-selection modals.

This PR stops treating the iframe URL as the API. In selection mode, the admin items UI publishes a plain JSON snapshot (`selectedItems`, `query`, `href`, `collectionId`) over a same-origin `BroadcastChannel` (`tainacan-selection`). Gutenberg caches the last snapshot and Apply reads that. Gutenberg never reads `Location`, `contentWindow`, or `#itemsFrame`. Search filters still live in the hash; `href` in the snapshot is the full admin URL for “use this search” blocks.

Also:

- Guard empty/`NaN` `itemId` on apply, and stop child metadata blocks from looping `setAttributes` when context `itemId` is `NaN` (that caused “Maximum update depth exceeded”).
- Document the channel contract for extenders who embed the admin items list in their own iframe instead of the React modals, including a `BroadcastChannel` snippet. Do not scrape iframe URL changes.

Admin bulk edit / cross-page selection is unchanged (Vuex `search.selecteditems` and `$route.query`).

## Related issue

Closes #1132

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would change existing behavior)
- [ ] Refactor / technical debt (no user-facing change)
- [x] Documentation

> Extenders who read selected IDs from the iframe `Location` (not a documented API) need to subscribe to `tainacan-selection` instead. See `docs/react-selection-modules.md`.

## Checklist

- [x] My code follows the project's coding standards (ESLint / PHPCS)
- [x] I have tested my changes locally
- [ ] I have added or updated tests when applicable
- [ ] If I changed a Gutenberg block's `block.json` or `save.js`, I updated the corresponding `deprecated.js`
- [x] I have updated the documentation when needed
- [ ] For UI changes, I have added screenshots or a screen recording below

## Screenshots / recordings

No visual UI change. After this fix, applying an item in the selection modal on WP 7.1 + Chrome should set the block without a console `SecurityError`.