### PR TITLE
feat: Add filter and media type info to help themes customize download button

### DIFF
--- a/src/classes/tainacan-utils.php
+++ b/src/classes/tainacan-utils.php
@@ -228,6 +228,14 @@ add_filter('wp_kses_allowed_html', function($allowedposttags, $context) {
 			);
 			// Add SVG support (reusing shared SVG rules)
 			return array_merge($post_allowed_html, tainacan_get_svg_allowed_html());
+		case 'tainacan_media_slide':
+			$allowed = wp_kses_allowed_html('tainacan_content');
+			if ( ! isset( $allowed['div'] ) || ! is_array( $allowed['div'] ) ) {
+				$allowed['div'] = array();
+			}
+			$allowed['div']['data-media-type'] = true;
+			$allowed['div']['data-media-source'] = true;
+			return $allowed;
 		case 'tainacan_menu_link':
 			$post_allowed_html = wp_kses_allowed_html('post');
 			return array_merge(

--- a/src/classes/theme-helper/class-tainacan-theme-helper.php
+++ b/src/classes/theme-helper/class-tainacan-theme-helper.php
@@ -2132,11 +2132,10 @@ class Theme_Helper {
 					$document_description = ($attachment instanceof \WP_Post) ? $attachment->post_content : '';
 				}
 
+				$document_download_link = tainacan_get_the_item_document_download_link($item_id);
 				$media_items_main[] =
 					tainacan_get_the_media_component_slide(array(
-						'after_slide_metadata' => (( $show_download_button_main && tainacan_the_item_document_download_link($item_id) != '' ) ?
-														sprintf('<span class="tainacan-item-file-download">%s</span>', tainacan_the_item_document_download_link($item_id))
-												: ''),
+						'after_slide_metadata' => ( $show_download_button_main && $document_download_link != '' ) ? $document_download_link : '',
 						'media_content' => tainacan_get_the_document($item_id),
 						'media_content_full' => $open_lightbox_on_click ?
 												(
@@ -2147,7 +2146,8 @@ class Theme_Helper {
 						'media_title' => $document_type === 'attachment' ? get_the_title(tainacan_get_the_document_raw($item_id)) : '',
 						'media_description' => $document_type === 'attachment' ? $document_description : '',
 						'media_caption' => $document_type === 'attachment' ? wp_get_attachment_caption(tainacan_get_the_document_raw($item_id)) : '',
-						'media_type' => tainacan_get_the_document_type($item_id),
+						'media_type' => tainacan_get_the_document_mimetype($item_id),
+						'media_source' => 'document',
 						'class_slide_metadata' => $class_slide_metadata
 					));
 			}
@@ -2156,11 +2156,10 @@ class Theme_Helper {
 				foreach ( $attachments as $attachment ) {
 					$is_attachment_an_image = wp_attachment_is('image', $attachment->ID);
 
+					$attachment_download_link = tainacan_get_the_item_attachment_download_link($attachment->ID);
 					$media_items_main[] =
 						tainacan_get_the_media_component_slide(array(
-							'after_slide_metadata' => (( $show_download_button_main && tainacan_the_item_attachment_download_link($attachment->ID) != '' ) ?
-															sprintf('<span class="tainacan-item-file-download">%s</span>', tainacan_the_item_attachment_download_link($attachment->ID))
-													: ''),
+							'after_slide_metadata' => ( $show_download_button_main && $attachment_download_link != '' ) ? $attachment_download_link : '',
 							'media_content' => tainacan_get_attachment_as_html($attachment->ID, $item_id),
 							'media_content_full' => $open_lightbox_on_click ?
 													( 
@@ -2172,6 +2171,7 @@ class Theme_Helper {
 							'media_description' => $attachment->post_content,
 							'media_caption' => $attachment->post_excerpt,
 							'media_type' => $attachment->post_mime_type,
+							'media_source' => 'attachment',
 							'class_slide_metadata' => $class_slide_metadata
 						));
 				}
@@ -2203,7 +2203,8 @@ class Theme_Helper {
 						'media_title' => $is_document_type_attachment ? get_the_title(tainacan_get_the_document_raw($item_id)) : '',
 						'media_description' => $is_document_type_attachment ? get_the_content(null, false, tainacan_get_the_document_raw($item_id)) : '',
 						'media_caption' => $is_document_type_attachment ? wp_get_attachment_caption(tainacan_get_the_document_raw($item_id)) : '',
-						'media_type' => tainacan_get_the_document_type($item_id),
+						'media_type' => tainacan_get_the_document_mimetype($item_id),
+						'media_source' => 'document',
 						'class_slide_metadata' => $class_slide_metadata
 					));			
 			}
@@ -2219,6 +2220,7 @@ class Theme_Helper {
 							'media_description' => $attachment->post_content,
 							'media_caption' => $attachment->post_excerpt,
 							'media_type' => $attachment->post_mime_type,
+							'media_source' => 'attachment',
 							'class_slide_metadata' => $class_slide_metadata
 						));
 				}
@@ -2341,10 +2343,10 @@ class Theme_Helper {
 		// Apply wp_kses to ensure safety while preserving necessary HTML elements and attributes
 		// The content is already escaped in tainacan_get_the_media_component(), but we apply
 		// wp_kses here to satisfy plugin check requirements and ensure filter output is safe
-		// The 'tainacan_content' context now includes data-module and SVG support
+		// The 'tainacan_media_slide' context extends tainacan_content with data-media-type.
 		// Temporarily add safe_style_css filter to allow CSS properties needed for .media-full-content
 		add_filter('safe_style_css', 'tainacan_get_default_allowed_styles', 10, 1);
-		$gallery_html = wp_kses($gallery_html, wp_kses_allowed_html('tainacan_content'));
+		$gallery_html = wp_kses($gallery_html, wp_kses_allowed_html('tainacan_media_slide'));
 		remove_filter('safe_style_css', 'tainacan_get_default_allowed_styles', 10);
 		
 		return apply_filters(
@@ -2519,7 +2521,8 @@ class Theme_Helper {
 						'media_title' => $item ? $item->get_title() : '',
 						'media_description' =>  $item ? $item->get_description() : '',
 						'media_caption' => '<a href="' . esc_url(get_permalink($item_id)) . '" target="_blank" rel="noopener noreferrer">' . __( 'Visit the page', 'tainacan' ) . '</a>',
-						'media_type' => tainacan_get_the_document_type($item_id),
+						'media_type' => tainacan_get_the_document_mimetype($item_id),
+						'media_source' => 'document',
 						'class_slide_metadata' => $class_slide_metadata
 					));
 			
@@ -2550,7 +2553,8 @@ class Theme_Helper {
 						'media_title' => $item ? $item->get_title() : '',
 						'media_description' => $item ? $item->get_description() : '',
 						'media_caption' => '<a href="' . esc_url(get_permalink($item_id)) . '" target="_blank" rel="noopener noreferrer">' . __( 'Visit the page', 'tainacan' ) . '</a>',
-						'media_type' => tainacan_get_the_document_type($item_id),
+						'media_type' => tainacan_get_the_document_mimetype($item_id),
+						'media_source' => 'document',
 						'class_slide_metadata' => $class_slide_metadata
 					));			
 			}
@@ -2672,10 +2676,10 @@ class Theme_Helper {
 		// Apply wp_kses to ensure safety while preserving necessary HTML elements and attributes
 		// The content is already escaped in tainacan_get_the_media_component(), but we apply
 		// wp_kses here to satisfy plugin check requirements and ensure filter output is safe
-		// The 'tainacan_content' context now includes data-module and SVG support
+		// The 'tainacan_media_slide' context extends tainacan_content with data-media-type.
 		// Temporarily add safe_style_css filter to allow CSS properties needed for .media-full-content
 		add_filter('safe_style_css', 'tainacan_get_default_allowed_styles', 10, 1);
-		$gallery_html = wp_kses($gallery_html, wp_kses_allowed_html('tainacan_content'));
+		$gallery_html = wp_kses($gallery_html, wp_kses_allowed_html('tainacan_media_slide'));
 		remove_filter('safe_style_css', 'tainacan_get_default_allowed_styles', 10);
 		
 		return apply_filters(

--- a/src/classes/theme-helper/template-tags.php
+++ b/src/classes/theme-helper/template-tags.php
@@ -164,15 +164,38 @@ function tainacan_get_the_document_type($item_id = 0) {
 /**
  * To be used inside The Loop
  *
+ * Return the item document MIME type. For attachment documents this is the file MIME type
+ * (e.g. 'image/jpeg', 'application/pdf'). For URL or text documents this is the document type itself.
+ *
+ * @param int|string $item_id (Optional) The item ID. Default is the global $post
+ *
+ * @return string The document MIME type or document type, or empty string if item is not found
+ */
+function tainacan_get_the_document_mimetype($item_id = 0) {
+	$item = tainacan_get_item($item_id);
+
+	if ( ! $item instanceof \Tainacan\Entities\Item ) {
+		return '';
+	}
+
+	$mimetype = $item->get_document_mimetype();
+
+	return apply_filters( 'tainacan_get_the_document_mimetype', $mimetype ? $mimetype : '', $item );
+}
+
+/**
+ * To be used inside The Loop
+ *
  * Return the item document download link as HTML.
  *
  * Only returns a link for attachment-type documents. Returns empty string for text or URL documents.
+ * The HTML includes a `.tainacan-item-file-download` wrapper around the link so themes can style the control.
  *
  * @param int|string $item_id (Optional) The item ID. Default is the global $post
  *
  * @return string The HTML download link, or empty string if item is not found, has no document, or document is not downloadable
  */
-function tainacan_the_item_document_download_link($item_id = 0) {
+function tainacan_get_the_item_document_download_link($item_id = 0) {
 	$item = tainacan_get_item($item_id);
 
 	if ( ! $item instanceof \Tainacan\Entities\Item ) {
@@ -180,31 +203,96 @@ function tainacan_the_item_document_download_link($item_id = 0) {
 	}
 
 	$link = $item->get_document_download_url();
-	
-	if ( ! $link || $item->get_document_type() == 'text' || $item->get_document_type() == 'url' ) {
-		return '';
+	$html = '';
+
+	if ( $link && $item->get_document_type() != 'text' && $item->get_document_type() != 'url' ) {
+		$html = sprintf(
+			'<span class="tainacan-item-file-download"><a download="%1$s" href="%1$s" target="_blank" aria-label="%2$s"><span class="tainacan-item-file-download__label">%3$s</span></a></span>',
+			esc_url( $link ),
+			esc_attr( __( 'Download the item document', 'tainacan' ) ),
+			esc_html( __( 'Download', 'tainacan' ) )
+		);
 	}
 
-	return '<a name="' . __('Download the item document', 'tainacan') . '" download="'. esc_url($link) . '" href="' . esc_url($link) . '" target="_blank">' . __('Download', 'tainacan') . '</a>';
+	/**
+	 * Filters the item document download link HTML.
+	 *
+	 * @param string                  $html The HTML download link, or empty string.
+	 * @param \Tainacan\Entities\Item $item The item object.
+	 * @param string|false            $link The document download URL.
+	 */
+	return apply_filters( 'tainacan_get_the_item_document_download_link', $html, $item, $link );
+}
+
+/**
+ * To be used inside The Loop
+ *
+ * Return the item document download link as HTML.
+ *
+ * Only returns a link for attachment-type documents. Returns empty string for text or URL documents.
+ *
+ * Unlike typical WordPress `the_*` helpers, this function returns the HTML instead of echoing it.
+ * The original implementation returned a string and themes concatenate that value, so echoing
+ * here would break existing templates. Prefer tainacan_get_the_item_document_download_link() in new code.
+ *
+ * @param int|string $item_id (Optional) The item ID. Default is the global $post
+ *
+ * @return string The HTML download link, or empty string if item is not found, has no document, or document is not downloadable
+ */
+function tainacan_the_item_document_download_link($item_id = 0) {
+	return tainacan_get_the_item_document_download_link($item_id);
 }
 
 
 /**
  * Return the item attachment download link as HTML.
+ * The HTML includes a `.tainacan-item-file-download` wrapper around the link so themes can style the control.
+ *
+ * @param int $attachment_id The attachment ID
+ *
+ * @return string The HTML download link, or empty string if attachment is not found or has no URL
+ */
+function tainacan_get_the_item_attachment_download_link($attachment_id) {
+
+	if ( ! $attachment_id ) {
+		return '';
+	}
+
+	$link = wp_get_attachment_url($attachment_id);
+	$html = '';
+
+	if ( $link ) {
+		$html = sprintf(
+			'<span class="tainacan-item-file-download"><a download="%1$s" href="%1$s" aria-label="%2$s"><span class="tainacan-item-file-download__label">%3$s</span></a></span>',
+			esc_url( $link ),
+			esc_attr( __( 'Download the item attachment', 'tainacan' ) ),
+			esc_html( __( 'Download', 'tainacan' ) )
+		);
+	}
+
+	/**
+	 * Filters the item attachment download link HTML.
+	 *
+	 * @param string     $html          The HTML download link, or empty string.
+	 * @param int        $attachment_id The attachment ID.
+	 * @param string|false $link        The attachment URL.
+	 */
+	return apply_filters( 'tainacan_get_the_item_attachment_download_link', $html, $attachment_id, $link );
+}
+
+/**
+ * Return the item attachment download link as HTML.
+ *
+ * Unlike typical WordPress `the_*` helpers, this function returns the HTML instead of echoing it.
+ * The original implementation returned a string and themes concatenate that value, so echoing
+ * here would break existing templates. Prefer tainacan_get_the_item_attachment_download_link() in new code.
  *
  * @param int $attachment_id The attachment ID
  *
  * @return string The HTML download link, or empty string if attachment is not found or has no URL
  */
 function tainacan_the_item_attachment_download_link($attachment_id) {
-
-	if ( ! $attachment_id || ! wp_get_attachment_url($attachment_id) ) {
-		return '';
-	}
-
-	$link = wp_get_attachment_url($attachment_id);
-
-	return '<a name="' . __('Download the item attachment', 'tainacan') . '" download="'. esc_url($link) . '" href="' . esc_url($link) . '">' . __('Download', 'tainacan') . '</a>';
+	return tainacan_get_the_item_attachment_download_link($attachment_id);
 }
 
 /**
@@ -512,6 +600,7 @@ function tainacan_get_the_media_component(
 			'fill' => true,
 		)
 	);
+	$media_slide_allowed_html = wp_kses_allowed_html('tainacan_media_slide');
 	add_filter( 'safe_style_css', 'tainacan_get_default_allowed_styles');
 
 	ob_start();
@@ -543,7 +632,7 @@ function tainacan_get_the_media_component(
 							<?php foreach($media_items_main as $media_item) { ?>
 								<li class="tainacan-media-item <?php echo !$args['disable_main_carousel'] ? 'swiper-slide ' : '' ?> <?php echo esc_attr($args['class_main_li']) ?>">
 									<?php 
-										echo wp_kses($media_item, wp_kses_allowed_html('tainacan_content'));
+										echo wp_kses($media_item, $media_slide_allowed_html);
 									?>
 								</li>
 							<?php }; ?>
@@ -551,7 +640,7 @@ function tainacan_get_the_media_component(
 					<?php elseif ( count($media_items_main) === 1 ) : ?>
 						<div class="tainacan-media-items <?php echo !$args['disable_main_carousel'] ? 'swiper-wrapper ' : '' ?> <?php echo esc_attr($args['class_main_ul']) ?>">
 							<div class="tainacan-media-item <?php echo !$args['disable_main_carousel'] ? 'swiper-slide ' : '' ?> <?php echo esc_attr($args['class_main_li']) ?>">
-								<?php echo wp_kses($media_items_main[0], wp_kses_allowed_html('tainacan_content')); ?>
+								<?php echo wp_kses($media_items_main[0], $media_slide_allowed_html); ?>
 							</div>
 						</div>
 					<?php endif; ?>
@@ -608,14 +697,14 @@ function tainacan_get_the_media_component(
 						<ul class="tainacan-media-items <?php echo !$args['disable_thumbs_carousel'] ? 'swiper-wrapper ' : '' ?> <?php echo esc_attr($args['class_thumbs_ul']) ?>">
 							<?php foreach($media_items_thumbs as $media_item) { ?>
 								<li class="tainacan-media-item <?php echo !$args['disable_thumbs_carousel'] ? 'swiper-slide ' : '' ?> <?php echo esc_attr($args['class_thumbs_li']) ?>">
-									<?php echo wp_kses($media_item, wp_kses_allowed_html('tainacan_content')); ?>
+									<?php echo wp_kses($media_item, $media_slide_allowed_html); ?>
 								</li>
 							<?php }; ?>
 						</ul>
 					<?php elseif ( count($media_items_thumbs) === 1 ) : ?>
 						<div class="tainacan-media-items <?php echo !$args['disable_thumbs_carousel'] ? 'swiper-wrapper ' : '' ?> <?php echo esc_attr($args['class_thumbs_ul']) ?>">
 							<div class="tainacan-media-item <?php echo !$args['disable_thumbs_carousel'] ? 'swiper-slide ' : '' ?> <?php echo esc_attr($args['class_thumbs_li']) ?>">
-								<?php echo wp_kses($media_items_thumbs[0], wp_kses_allowed_html('tainacan_content')); ?>
+								<?php echo wp_kses($media_items_thumbs[0], $media_slide_allowed_html); ?>
 							</div>
 						</div>
 					<?php endif; ?>
@@ -692,7 +781,8 @@ function tainacan_get_the_media_component(
  *     @type string      media_title             The media title, if available
  *     @type string      media_description       The media description, if available
  *     @type string      media_caption           The media caption, if available
- *     @type string      media_type              The media type or mime_type, used to render an icon if media_content is empty
+ *     @type string      media_type              The media type or mime_type, used to render an icon if media_content is empty. Also output as data-media-type on the slide content wrapper.
+ *     @type string      media_source            The media source, either 'document' or 'attachment'. Also output as data-media-source on the slide content wrapper.
  * }
  * @return string
  */
@@ -711,7 +801,8 @@ function tainacan_get_the_media_component_slide( $args = array() ) {
 		'media_title' => '',
 		'media_description' => '',
 		'media_caption' => '',
-		'media_type' => ''
+		'media_type' => '',
+		'media_source' => ''
 	), $args);
 
 	ob_start();
@@ -719,7 +810,10 @@ function tainacan_get_the_media_component_slide( $args = array() ) {
 ?>
 	<?php echo wp_kses_post($args['before_slide_content']) ?>
 
-	<div class="swiper-slide-content <?php echo esc_attr($args['class_slide_content']) ?>">
+	<div class="swiper-slide-content <?php echo esc_attr($args['class_slide_content']) ?>"<?php
+		echo ! empty( $args['media_type'] ) ? ' data-media-type="' . esc_attr( $args['media_type'] ) . '"' : '';
+		echo ! empty( $args['media_source'] ) ? ' data-media-source="' . esc_attr( $args['media_source'] ) . '"' : '';
+	?>>
 
 		<?php if ( isset($args['media_content']) && !empty($args['media_content']) && $args['media_content'] !== false ) :?>
 			<?php echo wp_kses($args['media_content'], wp_kses_allowed_html('tainacan_content')) ?>


### PR DESCRIPTION
## Description

Makes the media gallery download control something themes can restyle, instead of adding block options for label, hover, position, and the rest. Those would serialize into post content, fight theme CSS, and still leave cases that need CSS (especially mobile PDF). The gallery still only toggles visibility (`showDownloadButtonMain`).

**Markup** now comes from the template tags (one wrapper, not a second wrap in the gallery):

```html
<span class="tainacan-item-file-download">
  <a download="…" href="…" aria-label="…">
    <span class="tainacan-item-file-download__label">Download</span>
  </a>
</span>
```

Same `.tainacan-item-file-download` class as today, so Interface and Blocksy keep working. `__label` is there so themes can hide the text without `font-size: 0`. `aria-label` replaces the invalid `name` attribute.

**Filters:** `tainacan_get_the_item_document_download_link` and `tainacan_get_the_item_attachment_download_link` (`$html`, item or attachment, URL). The old `tainacan_the_*` functions still **return** HTML (they never echoed; existing templates concatenate the result).

**Plugin CSS** stays out of cosmetics (no colors, radius, or `inline-flex`) so the control looks like a normal theme link and overlay-icon themes are not overridden.

**Slide hooks** for per-file CSS, including PDFs:

- `data-media-type` — MIME type (`application/pdf`, `image/jpeg`); URL/text stay `url` / `text`
- `data-media-source` — `document` or `attachment`

Allowed only via the `tainacan_media_slide` kses context. New helper: `tainacan_get_the_document_mimetype()`.

## Related issue

Closes #991

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would change existing behavior)
- [ ] Refactor / technical debt (no user-facing change)
- [ ] Documentation

## Checklist

- [ ] My code follows the project's coding standards (ESLint / PHPCS)
- [ ] I have tested my changes locally
- [ ] I have added or updated tests when applicable
- [ ] If I changed a Gutenberg block's `block.json` or `save.js`, I updated the corresponding `deprecated.js`
- [ ] I have updated the documentation when needed
- [ ] For UI changes, I have added screenshots or a screen recording below