### PR TITLE
feat: Adds an option to render cover image instead of embed to certain mime types in the media gallery

### DIFF
--- a/src/classes/media-helper/class-tainacan-media.php
+++ b/src/classes/media-helper/class-tainacan-media.php
@@ -470,6 +470,32 @@ class Media {
 	}
 
 	/**
+	 * Normalizes a list of MIME types.
+	 *
+	 * @param mixed $mime_types Array of MIME types.
+	 * @return array
+	 */
+	public function normalize_mime_types( $mime_types ) {
+		if ( ! is_array( $mime_types ) ) {
+			return array();
+		}
+
+		$normalized = array();
+		foreach ( $mime_types as $mime_type ) {
+			if ( ! is_string( $mime_type ) ) {
+				continue;
+			}
+
+			$mime_type = sanitize_mime_type( strtolower( trim( $mime_type ) ) );
+			if ( $mime_type !== '' ) {
+				$normalized[] = $mime_type;
+			}
+		}
+
+		return array_values( array_unique( $normalized ) );
+	}
+
+	/**
 	 * Extract an image from the first page of a pdf file
 	 *
 	 * @param  string $filepath The pdf filepath in the server
@@ -509,6 +535,78 @@ class Media {
 		} catch (\Error $ex) {
 			return null;
 		}
+	}
+
+	/**
+	 * Returns HTML for an attachment cover image.
+	 *
+	 * Cascade: attachment featured image → WordPress generated image → empty string.
+	 *
+	 * @param int    $attachment_id Attachment ID.
+	 * @param string $size          Image size. Default 'large'.
+	 * @param bool   $wrap_in_link  Whether to wrap the image in a link to the attachment file.
+	 * @return string
+	 */
+	public function get_attachment_cover_html( $attachment_id, $size = 'large', $wrap_in_link = false ) {
+		$attachment_id = absint( $attachment_id );
+		if ( ! $attachment_id ) {
+			return '';
+		}
+
+		$cover = get_the_post_thumbnail( $attachment_id, $size );
+		if ( empty( $cover ) ) {
+			$cover = wp_get_attachment_image( $attachment_id, $size, false );
+		}
+
+		if ( empty( $cover ) ) {
+			return '';
+		}
+
+		if ( ! $wrap_in_link ) {
+			return $cover;
+		}
+
+		$url = wp_get_attachment_url( $attachment_id );
+		if ( ! $url ) {
+			return $cover;
+		}
+
+		return sprintf( '<a class="tainacan-media-cover" href="%s" target="blank">%s</a>', esc_url( $url ), $cover );
+	}
+
+	/**
+	 * Returns HTML for an item document cover image.
+	 *
+	 * Cascade: item featured image → attachment cover → empty string.
+	 *
+	 * @param int    $item_id      Item ID.
+	 * @param string $size         Image size. Default 'large'.
+	 * @param bool   $wrap_in_link Whether to wrap the image in a link to the document file.
+	 * @return string
+	 */
+	public function get_item_document_cover_html( $item_id, $size = 'large', $wrap_in_link = false ) {
+		$item_id = absint( $item_id );
+		if ( ! $item_id ) {
+			return '';
+		}
+
+		$cover = get_the_post_thumbnail( $item_id, $size );
+		if ( empty( $cover ) ) {
+			$document_id = tainacan_get_the_document_raw( $item_id );
+			return is_numeric( $document_id ) ? $this->get_attachment_cover_html( (int) $document_id, $size, $wrap_in_link ) : '';
+		}
+
+		if ( ! $wrap_in_link ) {
+			return $cover;
+		}
+
+		$document_id = tainacan_get_the_document_raw( $item_id );
+		$url = is_numeric( $document_id ) ? wp_get_attachment_url( (int) $document_id ) : '';
+		if ( ! $url ) {
+			return $cover;
+		}
+
+		return sprintf( '<a class="tainacan-media-cover" href="%s" target="blank">%s</a>', esc_url( $url ), $cover );
 	}
 
 	private $THROW_EXCPTION_ON_FATAL_ERROR = false;

--- a/src/classes/theme-helper/class-tainacan-theme-helper.php
+++ b/src/classes/theme-helper/class-tainacan-theme-helper.php
@@ -2002,8 +2002,10 @@ class Theme_Helper {
 		* 	   @type bool 	 $hideFileDescriptionLightbox	  Hides the Lightbox file description
 		* 	   @type bool 	 $openLightboxOnClick 			  Enables the behaviour of opening a lightbox with zoom when clicking on the media item
 		*	   @type bool	 $showDownloadButtonMain		  Displays a download button below the Main slider
+		*	   @type array	 $coverMimeTypesMain			  MIME types that should show a cover image in the Main slider instead of an embed. Defaults to empty (current embed behaviour).
 		*	   @type bool	 $lightboxHasLightBackground      Show a light background instead of dark in the lightbox 
 		*	   @type bool    $showArrowsAsSVG				  Decides if the swiper carousel arrows will be an SVG icon or font icon
+		*	   @type string  $mainImagesSize				  Media size for the Main slider images. Defaults to 'large'
 		*	   @type string  $thumbnailsSize				  Media size for the thumbnail images. Defaults to 'tainacan-medium'
 		*	   @type bool  	 $thumbsHaveFixedHeight			  If thumbs should have a fixed height and auto widht. Defaults to false.
 		* }		
@@ -2031,8 +2033,10 @@ class Theme_Helper {
 			'hideFileDescriptionLightbox' =>	false,
 			'openLightboxOnClick' => 			true,
 			'showDownloadButtonMain' =>			true,
+			'coverMimeTypesMain' =>				array(),
 			'lightboxHasLightBackground' => 	false,
 			'showArrowsAsSVG' =>				true,
+			'mainImagesSize' =>					'large',
 			'thumbnailsSize' =>					'tainacan-medium',
 			'thumbsHaveFixedHeight'	=>			false	
 		);
@@ -2044,6 +2048,14 @@ class Theme_Helper {
 			return;
 
 		$item_id = $item->get_id();
+
+		/**
+		 * Filters the arguments passed to get_tainacan_item_gallery().
+		 *
+		 * @param array                    $args The arguments passed to the function.
+		 * @param \Tainacan\Entities\Item $item The current item.
+		 */
+		$args = apply_filters( 'tainacan-get-item-gallery-filter-args', $args, $item );
 
 		// Gets options from block attributes
 		$block_id = $args['blockId'];
@@ -2062,8 +2074,12 @@ class Theme_Helper {
 		$show_download_button_main = $args['showDownloadButtonMain'];
 		$lightbox_has_light_background = $args['lightboxHasLightBackground'];
 		$show_arrows_as_svg = $args['showArrowsAsSVG'];
+		$main_images_size = $args['mainImagesSize'];
 		$thumbnails_size = $args['thumbnailsSize'];
 		$thumbs_have_fixed_height = $args['thumbsHaveFixedHeight'];
+
+		$media = Media::get_instance();
+		$cover_mime_types_main = $media->normalize_mime_types( $args['coverMimeTypesMain'] );
 
 		// Prefils arrays with proper values to avoid messsy IFs
 		$layout_elements = array(
@@ -2093,9 +2109,11 @@ class Theme_Helper {
 				$class_slide_metadata .= ' hide-caption';
 
 			// Checks if there is at least one image alongside the media sources
-			// to decide if loading the lighbox is worthy on the main slider
+			// to decide if loading the lighbox is worthy on the main slider.
+			// Cover MIME types also count, so a PDF-only gallery can still open PhotoSwipe.
 			if ($open_lightbox_on_click) {
 				$media_includes_images = false;
+				$media_includes_covers = false;
 
 				if ( $media_sources['document'] && !empty(tainacan_get_the_document($item_id)) ) {
 					$document_type = tainacan_get_the_document_type($item_id);
@@ -2103,7 +2121,12 @@ class Theme_Helper {
 					if ($document_type === 'attachment')  {
 						// Uses this moment to also see if we have an image
 						$attachment = get_post(tainacan_get_the_document_raw($item_id));
-						$media_includes_images = wp_attachment_is('image', $attachment->ID);
+						if ( $attachment instanceof \WP_Post ) {
+							$media_includes_images = wp_attachment_is('image', $attachment->ID);
+							if ( in_array( $attachment->post_mime_type, $cover_mime_types_main, true ) ) {
+								$media_includes_covers = true;
+							}
+						}
 					} else if ($document_type === 'url') {
 						$document_options = $item->get_document_options();
 						$media_includes_images = isset($document_options['is_image']) && $document_options['is_image'];
@@ -2116,15 +2139,24 @@ class Theme_Helper {
 
 						if ($is_attachment_an_image)
 							$media_includes_images = true; // Do not asign directly as we want to check if at least one is true
+
+						if ( in_array( $attachment->post_mime_type, $cover_mime_types_main, true ) ) {
+							$media_includes_covers = true;
+						}
 					}
 				}
 
-				if (!$media_includes_images)
+				if ( ! $media_includes_images && ! $media_includes_covers )
 					$open_lightbox_on_click = false;
 			}
 
 			if ( $media_sources['document'] && !empty(tainacan_get_the_document($item_id)) ) {
 				$document_type = tainacan_get_the_document_type($item_id);
+				$document_mimetype = tainacan_get_the_document_mimetype($item_id);
+				$document_uses_cover = ( $document_type === 'attachment' && in_array( $document_mimetype, $cover_mime_types_main, true ) );
+				$document_media_content = tainacan_get_the_document($item_id, $main_images_size);
+				$document_description = '';
+				$class_slide_content = '';
 				
 				// Document description is a bit more tricky
 				if ($document_type === 'attachment')  {
@@ -2132,11 +2164,16 @@ class Theme_Helper {
 					$document_description = ($attachment instanceof \WP_Post) ? $attachment->post_content : '';
 				}
 
+				if ( $document_uses_cover ) {
+					$document_media_content = $media->get_attachment_cover_html( tainacan_get_the_document_raw($item_id), $main_images_size, true );
+					$class_slide_content = 'has-cover';
+				}
+
 				$document_download_link = tainacan_get_the_item_document_download_link($item_id);
 				$media_items_main[] =
 					tainacan_get_the_media_component_slide(array(
 						'after_slide_metadata' => ( $show_download_button_main && $document_download_link != '' ) ? $document_download_link : '',
-						'media_content' => tainacan_get_the_document($item_id),
+						'media_content' => $document_media_content,
 						'media_content_full' => $open_lightbox_on_click ?
 												(
 													$document_type === 'attachment' ?
@@ -2146,8 +2183,9 @@ class Theme_Helper {
 						'media_title' => $document_type === 'attachment' ? get_the_title(tainacan_get_the_document_raw($item_id)) : '',
 						'media_description' => $document_type === 'attachment' ? $document_description : '',
 						'media_caption' => $document_type === 'attachment' ? wp_get_attachment_caption(tainacan_get_the_document_raw($item_id)) : '',
-						'media_type' => tainacan_get_the_document_mimetype($item_id),
+						'media_type' => $document_mimetype,
 						'media_source' => 'document',
+						'class_slide_content' => $class_slide_content,
 						'class_slide_metadata' => $class_slide_metadata
 					));
 			}
@@ -2155,12 +2193,20 @@ class Theme_Helper {
 			if ( $media_sources['attachments'] ) {
 				foreach ( $attachments as $attachment ) {
 					$is_attachment_an_image = wp_attachment_is('image', $attachment->ID);
+					$attachment_uses_cover = in_array( $attachment->post_mime_type, $cover_mime_types_main, true );
+					$attachment_media_content = tainacan_get_attachment_as_html($attachment->ID, $item_id, $main_images_size);
+					$class_slide_content = '';
+
+					if ( $attachment_uses_cover ) {
+						$attachment_media_content = $media->get_attachment_cover_html( $attachment->ID, $main_images_size, true );
+						$class_slide_content = 'has-cover';
+					}
 
 					$attachment_download_link = tainacan_get_the_item_attachment_download_link($attachment->ID);
 					$media_items_main[] =
 						tainacan_get_the_media_component_slide(array(
 							'after_slide_metadata' => ( $show_download_button_main && $attachment_download_link != '' ) ? $attachment_download_link : '',
-							'media_content' => tainacan_get_attachment_as_html($attachment->ID, $item_id),
+							'media_content' => $attachment_media_content,
 							'media_content_full' => $open_lightbox_on_click ?
 													( 
 														$is_attachment_an_image ?
@@ -2172,6 +2218,7 @@ class Theme_Helper {
 							'media_caption' => $attachment->post_excerpt,
 							'media_type' => $attachment->post_mime_type,
 							'media_source' => 'attachment',
+							'class_slide_content' => $class_slide_content,
 							'class_slide_metadata' => $class_slide_metadata
 						));
 				}
@@ -2211,10 +2258,9 @@ class Theme_Helper {
 
 			if ( $media_sources['attachments'] ) {
 				foreach ( $attachments as $attachment ) {
-					$attachment_thumbnail = get_the_post_thumbnail($attachment->ID, $thumbnails_size);
 					$media_items_thumbnails[] = 
 						tainacan_get_the_media_component_slide(array(
-							'media_content' => $attachment_thumbnail ? $attachment_thumbnail : wp_get_attachment_image( $attachment->ID, $thumbnails_size, false ),
+							'media_content' => $media->get_attachment_cover_html( $attachment->ID, $thumbnails_size ),
 							'media_content_full' => ( $open_lightbox_on_click && !$layout_elements['main'] ) ? ( wp_attachment_is('image', $attachment->ID) ? wp_get_attachment_image( $attachment->ID, 'full', false) : sprintf('<div class="attachment-without-image tainacan-embed-container"><iframe id="tainacan-attachment-iframe--%s" src="%s"></iframe></div>', $block_id, tainacan_get_attachment_html_url($attachment->ID)) ) : '',
 							'media_title' => $attachment->post_title,
 							'media_description' => $attachment->post_content,
@@ -2378,8 +2424,10 @@ class Theme_Helper {
 		* 	  @type bool 	 $hideItemLinkLightbox 		  	  Hides the Lightbox item link
 		* 	  @type bool 	 $hideItemDescriptionLightbox	  Hides the Lightbox file description
 		* 	  @type bool 	 $openLightboxOnClick 			  Enables the behaviour of opening a lightbox with zoom when clicking on the media item
+		*	  @type array	 $coverMimeTypesMain			  MIME types that should show a cover image in the Main slider instead of an embed. Defaults to empty (current embed behaviour).
 		*	  @type bool	 $lightboxHasLightBackground      Show a light background instead of dark in the lightbox 
 		*	  @type bool     $showArrowsAsSVG				  Decides if the swiper carousel arrows will be an SVG icon or font icon
+		*	  @type string   $mainImagesSize				  Media size for the Main slider images. Defaults to 'large'
 		*	  @type string   $thumbnailsSize				  Media size for the thumbnail images. Defaults to 'tainacan-medium'
 		*	  @type bool  	 $thumbsHaveFixedHeight			  If thumbs should have a fixed height and auto widht. Defaults to false.
 		* }		
@@ -2409,12 +2457,21 @@ class Theme_Helper {
 			'hideItemLinkLightbox' => 			false,
 			'hideItemDescriptionLightbox' =>	false,
 			'openLightboxOnClick' => 			true,
+			'coverMimeTypesMain' =>				array(),
 			'lightboxHasLightBackground' => 	false,
 			'showArrowsAsSVG' =>				true,
+			'mainImagesSize' =>					'large',
 			'thumbnailsSize' =>					'tainacan-medium',
 			'thumbsHaveFixedHeight'	=>			false	
 		);
 		$args = wp_parse_args($args, $defaults);
+
+		/**
+		 * Filters the arguments passed to get_tainacan_items_gallery().
+		 *
+		 * @param array $args The arguments passed to the function.
+		 */
+		$args = apply_filters( 'tainacan-get-items-gallery-filter-args', $args );
 
 		// Gets options from block attributes
 		$block_id = $args['blockId'];
@@ -2435,6 +2492,7 @@ class Theme_Helper {
 		$open_lightbox_on_click = $args['openLightboxOnClick'];
 		$lightbox_has_light_background = $args['lightboxHasLightBackground'];
 		$show_arrows_as_svg = $args['showArrowsAsSVG'];
+		$main_images_size = $args['mainImagesSize'];
 		$thumbnails_size = $args['thumbnailsSize'];
 		$thumbs_have_fixed_height = $args['thumbsHaveFixedHeight'];
 
@@ -2466,6 +2524,9 @@ class Theme_Helper {
 			$items_ids = array_map(function($item) { return $item['id']; }, $selected_items);
 		}
 
+		$media = Media::get_instance();
+		$cover_mime_types_main = $media->normalize_mime_types( $args['coverMimeTypesMain'] );
+
 		// Prepares the main slider
 		if ( $layout_elements['main'] ) {
 
@@ -2478,9 +2539,11 @@ class Theme_Helper {
 				$class_slide_metadata .= ' hide-caption';
 
 			// Checks if there is at least one image alongside the media sources
-			// to decide if loading the lighbox is worthy on the main slider
+			// to decide if loading the lighbox is worthy on the main slider.
+			// Cover MIME types also count, so a PDF-only gallery can still open PhotoSwipe.
 			if ($open_lightbox_on_click) {
 				$media_includes_images = false;
+				$media_includes_covers = false;
 
 				foreach( $items_ids as $item_id ) {
 
@@ -2490,28 +2553,43 @@ class Theme_Helper {
 						if ($document_type === 'attachment')  {
 							// Uses this moment to also see if we have an image
 							$attachment = get_post(tainacan_get_the_document_raw($item_id));
-							$media_includes_images = wp_attachment_is('image', $attachment->ID);
+							if ( $attachment instanceof \WP_Post ) {
+								$media_includes_images = wp_attachment_is('image', $attachment->ID);
+								if ( in_array( $attachment->post_mime_type, $cover_mime_types_main, true ) ) {
+									$media_includes_covers = true;
+								}
+							}
 						} else if ($document_type === 'url') {
 							$item = tainacan_get_item($item_id);
-							$document_options = $item->get_document_options();
+							$document_options = $item ? $item->get_document_options() : [];
 							$media_includes_images = isset($document_options['is_image']) && $document_options['is_image'];
 						}
-						if ( $media_includes_images )
+						if ( $media_includes_images || $media_includes_covers )
 							break;
 					}
 				}
 				
-				if ( !$media_includes_images )
+				if ( ! $media_includes_images && ! $media_includes_covers )
 					$open_lightbox_on_click = false;
 			}
 
 			// Adds Item's documents as main slider content
 			foreach( $items_ids as $item_id ) {
 				$item = tainacan_get_item($item_id);
+				$document_type = tainacan_get_the_document_type($item_id);
+				$document_mimetype = tainacan_get_the_document_mimetype($item_id);
+				$document_uses_cover = ( $document_type === 'attachment' && in_array( $document_mimetype, $cover_mime_types_main, true ) );
+				$document_media_content = tainacan_get_the_document($item_id, $main_images_size);
+				$class_slide_content = '';
+
+				if ( $document_uses_cover ) {
+					$document_media_content = $media->get_item_document_cover_html( $item_id, $main_images_size, true );
+					$class_slide_content = 'has-cover';
+				}
 
 				$media_items_main[] = 
 					tainacan_get_the_media_component_slide(array(
-						'media_content' => tainacan_get_the_document($item_id),
+						'media_content' => $document_media_content,
 						'media_content_full' => $open_lightbox_on_click ?
 												(
 													$document_type === 'attachment' ?
@@ -2521,8 +2599,9 @@ class Theme_Helper {
 						'media_title' => $item ? $item->get_title() : '',
 						'media_description' =>  $item ? $item->get_description() : '',
 						'media_caption' => '<a href="' . esc_url(get_permalink($item_id)) . '" target="_blank" rel="noopener noreferrer">' . __( 'Visit the page', 'tainacan' ) . '</a>',
-						'media_type' => tainacan_get_the_document_mimetype($item_id),
+						'media_type' => $document_mimetype,
 						'media_source' => 'document',
+						'class_slide_content' => $class_slide_content,
 						'class_slide_metadata' => $class_slide_metadata
 					));
 			
@@ -3228,8 +3307,10 @@ class Theme_Helper {
 		* 	   @type bool 	 $hideFileDescriptionLightbox	  Hides the Lightbox file description
 		* 	   @type bool 	 $openLightboxOnClick 			  Enables the behaviour of opening a lightbox with zoom when clicking on the media item
 		*	   @type bool	 $showDownloadButtonMain		  Displays a download button below the Main slider
+		*	   @type array	 $coverMimeTypesMain			  MIME types that should show a cover image in the Main slider instead of an embed. Defaults to empty (current embed behaviour).
 		*	   @type bool	 $lightboxHasLightBackground      Show a light background instead of dark in the lightbox 
 		*	   @type bool    $showArrowsAsSVG				  Decides if the swiper carousel arrows will be an SVG icon or font icon
+		*	   @type string  $mainImagesSize				  Media size for the Main slider images. Defaults to 'large'
 		*	   @type string  $thumbnailsSize	 		      Media size for the thumbnail images. Defaults to 'tainacan-medium'
 		*	   @type bool  	 $thumbsHaveFixedHeight			  If thumbs should have a fixed height and auto widht. Defaults to false.
 		* @return string  The HTML div to be used for rendering the item galery component
@@ -3256,8 +3337,10 @@ class Theme_Helper {
 			'hideFileDescriptionLightbox' =>	false,
 			'openLightboxOnClick' => 			true,
 			'showDownloadButtonMain' =>			true,
+			'coverMimeTypesMain' =>				array(),
 			'lightboxHasLightBackground' => 	false,
 			'showArrowsAsSVG' =>				true,
+			'mainImagesSize' =>					'large',
 			'thumbnailsSize' =>					'tainacan-medium',
 			'thumbsHaveFixedHeight' =>			false
 		);

--- a/src/classes/theme-helper/template-tags.php
+++ b/src/classes/theme-helper/template-tags.php
@@ -101,7 +101,7 @@ function tainacan_get_the_document($item_id = 0, $img_size = 'large') {
 		return '';
 	}
 
-	return apply_filters('tainacan-get-the-document', $item->get_document_as_html($item_id, $img_size), $item);
+	return apply_filters('tainacan-get-the-document', $item->get_document_as_html($img_size), $item);
 }
 
 /**
@@ -1489,8 +1489,10 @@ function tainacan_has_related_items($item_id = false) {
 	* 	   @type bool 	 $hideFileDescriptionLightbox	  Hides the Lightbox file description
 	* 	   @type bool 	 $openLightboxOnClick 			  Enables the behaviour of opening a lightbox with zoom when clicking on the media item
 	*	   @type bool	 $showDownloadButtonMain		  Displays a download button below the Main slider
+	*	   @type array	 $coverMimeTypesMain			  MIME types that should show a cover image in the Main slider instead of an embed. Defaults to empty (current embed behaviour).
 	*	   @type bool	 $lightboxHasLightBackground      Show a light background instead of dark in the lightbox 
 	*	   @type bool    $showArrowsAsSVG			      Decides if the swiper carousel arrows will be an SVG icon or font icon
+	*	   @type string  $mainImagesSize				  Media size for the Main slider images. Defaults to 'large'
 	*	   @type string  $thumbnailsSize				  Media size for the thumbnail images. Defaults to 'tainacan-medium'
 	*	   @type bool  	 $thumbsHaveFixedHeight			  If thumbs should have a fixed height and auto widht. Defaults to false.
 	* }		

--- a/src/views/gutenberg-blocks/blocks/item-gallery/block.json
+++ b/src/views/gutenberg-blocks/blocks/item-gallery/block.json
@@ -103,6 +103,13 @@
             "type": "boolean",
             "default": false
         },
+        "coverMimeTypesMain": {
+            "type": "array",
+            "default": [],
+            "items": {
+                "type": "string"
+            }
+        },
         "lightboxHasLightBackground": {
             "type": "boolean",
             "default": false
@@ -110,6 +117,10 @@
         "templateMode": {
             "type": "boolean",
             "default": false
+        },
+        "mainImagesSize": {
+            "type": "string",
+            "default": "large"
         },
         "thumbnailsSize": {
             "type": "string",

--- a/src/views/gutenberg-blocks/blocks/item-gallery/deprecated.js
+++ b/src/views/gutenberg-blocks/blocks/item-gallery/deprecated.js
@@ -1,4 +1,243 @@
 export default [
+    // Deprecated to add mainImagesSize option
+    {
+        "attributes": {
+            "blockId": {
+                "type": "string",
+                "default": ""
+            },
+            "collectionId": {
+                "type": "string",
+                "default": ""
+            },
+            "itemId": {
+                "type": "string",
+                "default": ""
+            },
+            "isModalOpen": {
+                "type": "boolean",
+                "default": false
+            },
+            "layoutElements": {
+                "type": "object",
+                "default": {
+                    "main": true,
+                    "thumbnails": true
+                }
+            },
+            "mediaSources": {
+                "type": "object",
+                "default": {
+                    "document": true,
+                    "attachments": true,
+                    "metadata": false
+                }
+            },
+            "hideFileNameMain": {
+                "type": "boolean",
+                "default": true
+            },
+            "hideFileCaptionMain": {
+                "type": "boolean",
+                "default": false
+            },
+            "hideFileDescriptionMain": {
+                "type": "boolean",
+                "default": true
+            },
+            "hideFileNameThumbnails": {
+                "type": "boolean",
+                "default": true
+            },
+            "hideFileCaptionThumbnails": {
+                "type": "boolean",
+                "default": true
+            },
+            "hideFileDescriptionThumbnails": {
+                "type": "boolean",
+                "default": true
+            },
+            "hideFileNameLightbox": {
+                "type": "boolean",
+                "default": false
+            },
+            "hideFileCaptionLightbox": {
+                "type": "boolean",
+                "default": false
+            },
+            "hideFileDescriptionLightbox": {
+                "type": "boolean",
+                "default": false
+            },
+            "openLightboxOnClick": {
+                "type": "boolean",
+                "default": true
+            },
+            "arrowsSize": {
+                "type": "integer",
+                "default": 44
+            },
+            "mainSliderHeight": {
+                "type": "integer",
+                "default": 60
+            },
+            "mainSliderWidth": {
+                "type": "integer",
+                "default": 100
+            },
+            "thumbnailsCarouselWidth": {
+                "type": "integer",
+                "default": 100
+            },
+            "thumbnailsCarouselItemSize": {
+                "type": "integer",
+                "default": 136
+            },
+            "showDownloadButtonMain": {
+                "type": "boolean",
+                "default": false
+            },
+            "coverMimeTypesMain": {
+                "type": "array",
+                "default": [],
+                "items": {
+                    "type": "string"
+                }
+            },
+            "lightboxHasLightBackground": {
+                "type": "boolean",
+                "default": false
+            },
+            "templateMode": {
+                "type": "boolean",
+                "default": false
+            },
+            "thumbnailsSize": {
+                "type": "string",
+                "default": "tainacan-medium"
+            },
+            "thumbsHaveFixedHeight": {
+                "type": "boolean",
+                "default": false
+            }
+        }
+    },
+    // Deprecated to add coverMimeTypesMain option
+    {
+        "attributes": {
+            "blockId": {
+                "type": "string",
+                "default": ""
+            },
+            "collectionId": {
+                "type": "string",
+                "default": ""
+            },
+            "itemId": {
+                "type": "string",
+                "default": ""
+            },
+            "isModalOpen": {
+                "type": "boolean",
+                "default": false
+            },
+            "layoutElements": {
+                "type": "object",
+                "default": {
+                    "main": true,
+                    "thumbnails": true
+                }
+            },
+            "mediaSources": {
+                "type": "object",
+                "default": {
+                    "document": true,
+                    "attachments": true,
+                    "metadata": false
+                }
+            },
+            "hideFileNameMain": {
+                "type": "boolean",
+                "default": true
+            },
+            "hideFileCaptionMain": {
+                "type": "boolean",
+                "default": false
+            },
+            "hideFileDescriptionMain": {
+                "type": "boolean",
+                "default": true
+            },
+            "hideFileNameThumbnails": {
+                "type": "boolean",
+                "default": true
+            },
+            "hideFileCaptionThumbnails": {
+                "type": "boolean",
+                "default": true
+            },
+            "hideFileDescriptionThumbnails": {
+                "type": "boolean",
+                "default": true
+            },
+            "hideFileNameLightbox": {
+                "type": "boolean",
+                "default": false
+            },
+            "hideFileCaptionLightbox": {
+                "type": "boolean",
+                "default": false
+            },
+            "hideFileDescriptionLightbox": {
+                "type": "boolean",
+                "default": false
+            },
+            "openLightboxOnClick": {
+                "type": "boolean",
+                "default": true
+            },
+            "arrowsSize": {
+                "type": "integer",
+                "default": 44
+            },
+            "mainSliderHeight": {
+                "type": "integer",
+                "default": 60
+            },
+            "mainSliderWidth": {
+                "type": "integer",
+                "default": 100
+            },
+            "thumbnailsCarouselWidth": {
+                "type": "integer",
+                "default": 100
+            },
+            "thumbnailsCarouselItemSize": {
+                "type": "integer",
+                "default": 136
+            },
+            "showDownloadButtonMain": {
+                "type": "boolean",
+                "default": false
+            },
+            "lightboxHasLightBackground": {
+                "type": "boolean",
+                "default": false
+            },
+            "templateMode": {
+                "type": "boolean",
+                "default": false
+            },
+            "thumbnailsSize": {
+                "type": "string",
+                "default": "tainacan-medium"
+            },
+            "thumbsHaveFixedHeight": {
+                "type": "boolean",
+                "default": false
+            }
+        }
+    },
     // Deprecated in version 0.20.4 to add thumbnailsSize option
     {
         "attributes": {

--- a/src/views/gutenberg-blocks/blocks/item-gallery/edit.js
+++ b/src/views/gutenberg-blocks/blocks/item-gallery/edit.js
@@ -252,8 +252,8 @@ export default function ({ attributes, setAttributes, isSelected, clientId }) {
                             }
                         />
                         <ToggleControl
-                            label={__('Show PDF cover instead of iframe', 'tainacan')}
-                            help={ __('PDF files in the main slider display a cover image instead of an embedded viewer. Other media types are not affected. The lightbox can still show the PDF.', 'tainacan') }
+                            label={__('Show PDF cover instead of embedded reader', 'tainacan')}
+                            help={ __('The lightbox can still show the PDF reader.', 'tainacan') }
                             checked={ Array.isArray( coverMimeTypesMain ) && coverMimeTypesMain.includes( 'application/pdf' ) }
                             onChange={ ( isChecked ) => {
                                 const mimeTypes = Array.isArray( coverMimeTypesMain ) ? [ ...coverMimeTypesMain ] : [];

--- a/src/views/gutenberg-blocks/blocks/item-gallery/edit.js
+++ b/src/views/gutenberg-blocks/blocks/item-gallery/edit.js
@@ -49,8 +49,10 @@ export default function ({ attributes, setAttributes, isSelected, clientId }) {
         thumbnailsCarouselWidth,
         thumbnailsCarouselItemSize,
         showDownloadButtonMain,
+        coverMimeTypesMain,
         lightboxHasLightBackground,
         templateMode,
+        mainImagesSize,
         thumbnailsSize,
         thumbsHaveFixedHeight
     } = attributes;
@@ -203,6 +205,16 @@ export default function ({ attributes, setAttributes, isSelected, clientId }) {
                             min={ 10 }
                             max={ 150 }
                         />
+                        <SelectControl
+                            label={__('Image size', 'tainacan')}
+                            help={ __('WordPress image size used for pictures in the main slider. The lightbox still uses the original file.', 'tainacan') }
+                            value={ mainImagesSize }
+                            options={ imageSizeOptions }
+                            onChange={ ( aMainImagesSize ) => {
+                                mainImagesSize = aMainImagesSize;
+                                setAttributes({ mainImagesSize: mainImagesSize });
+                            }}
+                        />
                         <ToggleControl
                             label={__('Hide file name', 'tainacan')}
                             checked={ hideFileNameMain }
@@ -238,6 +250,23 @@ export default function ({ attributes, setAttributes, isSelected, clientId }) {
                                     setAttributes({ showDownloadButtonMain: showDownloadButtonMain });
                                 } 
                             }
+                        />
+                        <ToggleControl
+                            label={__('Show PDF cover instead of iframe', 'tainacan')}
+                            help={ __('PDF files in the main slider display a cover image instead of an embedded viewer. Other media types are not affected. The lightbox can still show the PDF.', 'tainacan') }
+                            checked={ Array.isArray( coverMimeTypesMain ) && coverMimeTypesMain.includes( 'application/pdf' ) }
+                            onChange={ ( isChecked ) => {
+                                const mimeTypes = Array.isArray( coverMimeTypesMain ) ? [ ...coverMimeTypesMain ] : [];
+                                const hasPdfCover = mimeTypes.includes( 'application/pdf' );
+
+                                if ( isChecked && ! hasPdfCover ) {
+                                    mimeTypes.push( 'application/pdf' );
+                                } else if ( ! isChecked && hasPdfCover ) {
+                                    mimeTypes.splice( mimeTypes.indexOf( 'application/pdf' ), 1 );
+                                }
+
+                                setAttributes({ coverMimeTypesMain: mimeTypes });
+                            } }
                         />
                     </PanelBody>
                 : null }

--- a/src/views/gutenberg-blocks/blocks/item-gallery/theme.js
+++ b/src/views/gutenberg-blocks/blocks/item-gallery/theme.js
@@ -493,6 +493,7 @@ tainacan_plugin.classes.TainacanMediaGallery = class TainacanMediaGallery {
             const audio = mainLink ? mainLink.querySelector('audio') : slideContent.querySelector('audio');
             const figure = slideContent.querySelector('figure');
             const titleElement = slide.querySelector('.swiper-slide-metadata__name');
+            const mediaType = slideContent.getAttribute('data-media-type') || '';
             
             // Build aria-label based on media type
             let ariaLabelParts = [];
@@ -505,6 +506,8 @@ tainacan_plugin.classes.TainacanMediaGallery = class TainacanMediaGallery {
             } else if (audio) {
                 const audioTitle = audio.getAttribute('title') || audio.getAttribute('aria-label');
                 mediaDescription = audioTitle || __('Audio', 'tainacan');
+            } else if (mediaType === 'application/pdf') {
+                mediaDescription = __('PDF document', 'tainacan');
             } else if (iframe) {
                 // Check if it's a PDF, etc.
                 const iframeSrc = iframe.getAttribute('src') || '';

--- a/src/views/gutenberg-blocks/blocks/items-gallery/block.json
+++ b/src/views/gutenberg-blocks/blocks/items-gallery/block.json
@@ -112,6 +112,17 @@
             "type": "boolean",
             "default": false
         },
+        "coverMimeTypesMain": {
+            "type": "array",
+            "default": [],
+            "items": {
+                "type": "string"
+            }
+        },
+        "mainImagesSize": {
+            "type": "string",
+            "default": "large"
+        },
         "thumbnailsSize": {
             "type": "string",
             "default": "tainacan-medium"

--- a/src/views/gutenberg-blocks/blocks/items-gallery/deprecated.js
+++ b/src/views/gutenberg-blocks/blocks/items-gallery/deprecated.js
@@ -1,1 +1,230 @@
-export default [];
+export default [
+    // Deprecated to add coverMimeTypesMain option
+    {
+        "attributes": {
+            "blockId": {
+                "type": "string",
+                "default": ""
+            },
+            "items": {
+                "type": "array",
+                "default": []
+            },
+            "collectionId": {
+                "type": "string",
+                "default": ""
+            },
+            "searchURL": {
+                "type": "string",
+                "default": ""
+            },
+            "searchParams": {
+                "type": "object",
+                "default": {}
+            },
+            "selectedItems": {
+                "type": "array",
+                "default": []
+            },
+            "loadStrategy": {
+                "type": "string",
+                "default": "search"
+            },
+            "maxItemsNumber": {
+                "type": "number",
+                "default": 12
+            },
+            "isModalOpen": {
+                "type": "boolean",
+                "default": false
+            },
+            "layoutElements": {
+                "type": "object",
+                "default": {
+                    "main": true,
+                    "thumbnails": true
+                }
+            },
+            "hideItemTitleMain": {
+                "type": "boolean",
+                "default": true
+            },
+            "hideItemLinkMain": {
+                "type": "boolean",
+                "default": false
+            },
+            "hideItemDescriptionMain": {
+                "type": "boolean",
+                "default": true
+            },
+            "hideItemTitleThumbnails": {
+                "type": "boolean",
+                "default": true
+            },
+            "hideItemTitleLightbox": {
+                "type": "boolean",
+                "default": false
+            },
+            "hideItemLinkLightbox": {
+                "type": "boolean",
+                "default": false
+            },
+            "hideItemDescriptionLightbox": {
+                "type": "boolean",
+                "default": false
+            },
+            "openLightboxOnClick": {
+                "type": "boolean",
+                "default": true
+            },
+            "arrowsSize": {
+                "type": "integer",
+                "default": 44
+            },
+            "mainSliderHeight": {
+                "type": "integer",
+                "default": 60
+            },
+            "mainSliderWidth": {
+                "type": "integer",
+                "default": 100
+            },
+            "thumbnailsCarouselWidth": {
+                "type": "integer",
+                "default": 100
+            },
+            "thumbnailsCarouselItemSize": {
+                "type": "integer",
+                "default": 136
+            },
+            "lightboxHasLightBackground": {
+                "type": "boolean",
+                "default": false
+            },
+            "mainImagesSize": {
+                "type": "string",
+                "default": "large"
+            },
+            "thumbnailsSize": {
+                "type": "string",
+                "default": "tainacan-medium"
+            },
+            "thumbsHaveFixedHeight": {
+                "type": "boolean",
+                "default": false
+            }
+        }
+    },
+    // Deprecated to add mainImagesSize option
+    {
+        "attributes": {
+            "blockId": {
+                "type": "string",
+                "default": ""
+            },
+            "items": {
+                "type": "array",
+                "default": []
+            },
+            "collectionId": {
+                "type": "string",
+                "default": ""
+            },
+            "searchURL": {
+                "type": "string",
+                "default": ""
+            },
+            "searchParams": {
+                "type": "object",
+                "default": {}
+            },
+            "selectedItems": {
+                "type": "array",
+                "default": []
+            },
+            "loadStrategy": {
+                "type": "string",
+                "default": "search"
+            },
+            "maxItemsNumber": {
+                "type": "number",
+                "default": 12
+            },
+            "isModalOpen": {
+                "type": "boolean",
+                "default": false
+            },
+            "layoutElements": {
+                "type": "object",
+                "default": {
+                    "main": true,
+                    "thumbnails": true
+                }
+            },
+            "hideItemTitleMain": {
+                "type": "boolean",
+                "default": true
+            },
+            "hideItemLinkMain": {
+                "type": "boolean",
+                "default": false
+            },
+            "hideItemDescriptionMain": {
+                "type": "boolean",
+                "default": true
+            },
+            "hideItemTitleThumbnails": {
+                "type": "boolean",
+                "default": true
+            },
+            "hideItemTitleLightbox": {
+                "type": "boolean",
+                "default": false
+            },
+            "hideItemLinkLightbox": {
+                "type": "boolean",
+                "default": false
+            },
+            "hideItemDescriptionLightbox": {
+                "type": "boolean",
+                "default": false
+            },
+            "openLightboxOnClick": {
+                "type": "boolean",
+                "default": true
+            },
+            "arrowsSize": {
+                "type": "integer",
+                "default": 44
+            },
+            "mainSliderHeight": {
+                "type": "integer",
+                "default": 60
+            },
+            "mainSliderWidth": {
+                "type": "integer",
+                "default": 100
+            },
+            "thumbnailsCarouselWidth": {
+                "type": "integer",
+                "default": 100
+            },
+            "thumbnailsCarouselItemSize": {
+                "type": "integer",
+                "default": 136
+            },
+            "lightboxHasLightBackground": {
+                "type": "boolean",
+                "default": false
+            },
+            "thumbnailsSize": {
+                "type": "string",
+                "default": "tainacan-medium"
+            },
+            "thumbsHaveFixedHeight": {
+                "type": "boolean",
+                "default": false
+            }
+        }
+    }
+];

--- a/src/views/gutenberg-blocks/blocks/items-gallery/edit.js
+++ b/src/views/gutenberg-blocks/blocks/items-gallery/edit.js
@@ -45,6 +45,8 @@ export default function ({ attributes, setAttributes, isSelected, clientId }) {
         thumbnailsCarouselWidth,
         thumbnailsCarouselItemSize,
         lightboxHasLightBackground,
+        coverMimeTypesMain,
+        mainImagesSize,
         thumbnailsSize,
         thumbsHaveFixedHeight
     } = attributes;
@@ -405,6 +407,16 @@ export default function ({ attributes, setAttributes, isSelected, clientId }) {
                             min={ 10 }
                             max={ 150 }
                         />
+                        <SelectControl
+                            label={__('Image size', 'tainacan')}
+                            help={ __('WordPress image size used for pictures in the main slider. The lightbox still uses the original file.', 'tainacan') }
+                            value={ mainImagesSize }
+                            options={ imageSizeOptions }
+                            onChange={ ( aMainImagesSize ) => {
+                                mainImagesSize = aMainImagesSize;
+                                setAttributes({ mainImagesSize: mainImagesSize });
+                            }}
+                        />
                         <ToggleControl
                              label={__('Hide item link', 'tainacan')}
                              checked={ hideItemLinkMain }
@@ -431,6 +443,23 @@ export default function ({ attributes, setAttributes, isSelected, clientId }) {
                                     setAttributes({ hideItemDescriptionMain: hideItemDescriptionMain });
                                 } 
                             }
+                        />
+                        <ToggleControl
+                            label={__('Show PDF cover instead of iframe', 'tainacan')}
+                            help={ __('PDF files in the main slider display the item thumbnail or a cover image instead of an embedded viewer. Other media types are not affected. The lightbox can still show the PDF.', 'tainacan') }
+                            checked={ Array.isArray( coverMimeTypesMain ) && coverMimeTypesMain.includes( 'application/pdf' ) }
+                            onChange={ ( isChecked ) => {
+                                const mimeTypes = Array.isArray( coverMimeTypesMain ) ? [ ...coverMimeTypesMain ] : [];
+                                const hasPdfCover = mimeTypes.includes( 'application/pdf' );
+
+                                if ( isChecked && ! hasPdfCover ) {
+                                    mimeTypes.push( 'application/pdf' );
+                                } else if ( ! isChecked && hasPdfCover ) {
+                                    mimeTypes.splice( mimeTypes.indexOf( 'application/pdf' ), 1 );
+                                }
+
+                                setAttributes({ coverMimeTypesMain: mimeTypes });
+                            } }
                         />
                     </PanelBody>
                 : null }

--- a/src/views/gutenberg-blocks/blocks/items-gallery/edit.js
+++ b/src/views/gutenberg-blocks/blocks/items-gallery/edit.js
@@ -445,8 +445,8 @@ export default function ({ attributes, setAttributes, isSelected, clientId }) {
                             }
                         />
                         <ToggleControl
-                            label={__('Show PDF cover instead of iframe', 'tainacan')}
-                            help={ __('PDF files in the main slider display the item thumbnail or a cover image instead of an embedded viewer. Other media types are not affected. The lightbox can still show the PDF.', 'tainacan') }
+                            label={__('Show PDF cover instead of embedded reader', 'tainacan')}
+                            help={ __('The lightbox can still show the PDF reader.', 'tainacan') }
                             checked={ Array.isArray( coverMimeTypesMain ) && coverMimeTypesMain.includes( 'application/pdf' ) }
                             onChange={ ( isChecked ) => {
                                 const mimeTypes = Array.isArray( coverMimeTypesMain ) ? [ ...coverMimeTypesMain ] : [];


### PR DESCRIPTION
## Description

Adds an option for the Item Media Gallery and Items Gallery to show a **cover image** in the main slider instead of an embedded viewer (the PDF iframe, or other embeds later). The default stays the current iframe/embed behaviour.

In the Gutenberg block inspector this is a toggle: **Show PDF cover instead of iframe**. Under the hood it is a MIME type list, `coverMimeTypesMain` (default `[]`), so themes and filters can target more than PDF without a new boolean later.

When a document or attachment MIME type is in that list:
- the **main** slider uses a cover image (item featured image → attachment cover → MIME icon)
- the lightbox still shows the original embed
- PhotoSwipe stays enabled for cover-only galleries
- download is unchanged

Also included:
- `mainImagesSize` for both galleries (default `large`; lightbox stays `full`)
- `tainacan-get-item-gallery-filter-args` / `tainacan-get-items-gallery-filter-args` to filter gallery args after `wp_parse_args`
- media helpers: `normalize_mime_types()`, `get_attachment_cover_html()`, `get_item_document_cover_html()`
- block deprecations for the new attributes
- fix: `tainacan_get_the_document()` was passing an extra `$item_id` into `Item::get_document_as_html()`

Theme usage:

```php
tainacan_the_item_gallery([
    'cover_mime_types_main' => [ 'application/pdf' ],
]);

add_filter( 'tainacan-get-item-gallery-filter-args', function( $args ) {
    $args['coverMimeTypesMain'][] = 'application/pdf';
    return $args;
} );
```

## Related issue

Closes #1147

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would change existing behavior)
- [ ] Refactor / technical debt (no user-facing change)
- [ ] Documentation

## Checklist

- [x] My code follows the project's coding standards (ESLint / PHPCS)
- [x] I have tested my changes locally
- [ ] I have added or updated tests when applicable
- [x] If I changed a Gutenberg block's `block.json` or `save.js`, I updated the corresponding `deprecated.js`
- [x] I have updated the documentation when needed
- [ ] For UI changes, I have added screenshots or a screen recording below

## Screenshots / recordings

The two new settings in the gutenberg block inspector:

<img width="392" height="494" alt="image" src="https://github.com/user-attachments/assets/7227feca-7bcf-45fb-8c65-dfbabca5a58e" />