### PR TITLE
Feature/1149 item gallery expand control and a slide actions slot

### DIFF
--- a/src/classes/theme-helper/class-tainacan-theme-helper.php
+++ b/src/classes/theme-helper/class-tainacan-theme-helper.php
@@ -2170,18 +2170,10 @@ class Theme_Helper {
 				}
 
 				$document_download_link = tainacan_get_the_item_document_download_link($item_id);
-				$document_is_image = false;
-				if ( $document_type === 'attachment' ) {
-					$document_is_image = wp_attachment_is( 'image', tainacan_get_the_document_raw( $item_id ) );
-				} else if ( $document_type === 'url' ) {
-					$document_options = $item->get_document_options();
-					$document_is_image = isset( $document_options['is_image'] ) && $document_options['is_image'];
-				}
-
 				$media_items_main[] =
 					tainacan_get_the_media_component_slide(array(
 						'after_slide_metadata' => tainacan_get_the_media_item_actions( array(
-							'expand_html' => ( $open_lightbox_on_click && ! $document_is_image && ! $document_uses_cover ) ? tainacan_get_the_media_item_expand_control() : '',
+							'expand_html' => $open_lightbox_on_click ? tainacan_get_the_media_item_expand_control() : '',
 							'download_html' => ( $show_download_button_main && $document_download_link != '' ) ? $document_download_link : '',
 							'item_id' => $item_id,
 							'attachment_id' => ( $document_type === 'attachment' ) ? tainacan_get_the_document_raw( $item_id ) : 0,
@@ -2221,7 +2213,7 @@ class Theme_Helper {
 					$media_items_main[] =
 						tainacan_get_the_media_component_slide(array(
 							'after_slide_metadata' => tainacan_get_the_media_item_actions( array(
-								'expand_html' => ( $open_lightbox_on_click && ! $is_attachment_an_image && ! $attachment_uses_cover ) ? tainacan_get_the_media_item_expand_control() : '',
+								'expand_html' => $open_lightbox_on_click ? tainacan_get_the_media_item_expand_control() : '',
 								'download_html' => ( $show_download_button_main && $attachment_download_link != '' ) ? $attachment_download_link : '',
 								'item_id' => $item_id,
 								'attachment_id' => $attachment->ID,
@@ -2609,18 +2601,10 @@ class Theme_Helper {
 					$class_slide_content = 'has-cover';
 				}
 
-				$document_is_image = false;
-				if ( $document_type === 'attachment' ) {
-					$document_is_image = wp_attachment_is( 'image', tainacan_get_the_document_raw( $item_id ) );
-				} else if ( $document_type === 'url' ) {
-					$document_options = $item ? $item->get_document_options() : array();
-					$document_is_image = isset( $document_options['is_image'] ) && $document_options['is_image'];
-				}
-
 				$media_items_main[] = 
 					tainacan_get_the_media_component_slide(array(
 						'after_slide_metadata' => tainacan_get_the_media_item_actions( array(
-							'expand_html' => ( $open_lightbox_on_click && ! $document_is_image && ! $document_uses_cover ) ? tainacan_get_the_media_item_expand_control() : '',
+							'expand_html' => $open_lightbox_on_click ? tainacan_get_the_media_item_expand_control() : '',
 							'item_id' => $item_id,
 							'attachment_id' => ( $document_type === 'attachment' ) ? tainacan_get_the_document_raw( $item_id ) : 0,
 							'media_source' => 'document',

--- a/src/classes/theme-helper/class-tainacan-theme-helper.php
+++ b/src/classes/theme-helper/class-tainacan-theme-helper.php
@@ -2170,9 +2170,24 @@ class Theme_Helper {
 				}
 
 				$document_download_link = tainacan_get_the_item_document_download_link($item_id);
+				$document_is_image = false;
+				if ( $document_type === 'attachment' ) {
+					$document_is_image = wp_attachment_is( 'image', tainacan_get_the_document_raw( $item_id ) );
+				} else if ( $document_type === 'url' ) {
+					$document_options = $item->get_document_options();
+					$document_is_image = isset( $document_options['is_image'] ) && $document_options['is_image'];
+				}
+
 				$media_items_main[] =
 					tainacan_get_the_media_component_slide(array(
-						'after_slide_metadata' => ( $show_download_button_main && $document_download_link != '' ) ? $document_download_link : '',
+						'after_slide_metadata' => tainacan_get_the_media_item_actions( array(
+							'expand_html' => ( $open_lightbox_on_click && ! $document_is_image && ! $document_uses_cover ) ? tainacan_get_the_media_item_expand_control() : '',
+							'download_html' => ( $show_download_button_main && $document_download_link != '' ) ? $document_download_link : '',
+							'item_id' => $item_id,
+							'attachment_id' => ( $document_type === 'attachment' ) ? tainacan_get_the_document_raw( $item_id ) : 0,
+							'media_source' => 'document',
+							'media_type' => $document_mimetype,
+						) ),
 						'media_content' => $document_media_content,
 						'media_content_full' => $open_lightbox_on_click ?
 												(
@@ -2205,7 +2220,14 @@ class Theme_Helper {
 					$attachment_download_link = tainacan_get_the_item_attachment_download_link($attachment->ID);
 					$media_items_main[] =
 						tainacan_get_the_media_component_slide(array(
-							'after_slide_metadata' => ( $show_download_button_main && $attachment_download_link != '' ) ? $attachment_download_link : '',
+							'after_slide_metadata' => tainacan_get_the_media_item_actions( array(
+								'expand_html' => ( $open_lightbox_on_click && ! $is_attachment_an_image && ! $attachment_uses_cover ) ? tainacan_get_the_media_item_expand_control() : '',
+								'download_html' => ( $show_download_button_main && $attachment_download_link != '' ) ? $attachment_download_link : '',
+								'item_id' => $item_id,
+								'attachment_id' => $attachment->ID,
+								'media_source' => 'attachment',
+								'media_type' => $attachment->post_mime_type,
+							) ),
 							'media_content' => $attachment_media_content,
 							'media_content_full' => $open_lightbox_on_click ?
 													( 
@@ -2587,8 +2609,23 @@ class Theme_Helper {
 					$class_slide_content = 'has-cover';
 				}
 
+				$document_is_image = false;
+				if ( $document_type === 'attachment' ) {
+					$document_is_image = wp_attachment_is( 'image', tainacan_get_the_document_raw( $item_id ) );
+				} else if ( $document_type === 'url' ) {
+					$document_options = $item ? $item->get_document_options() : array();
+					$document_is_image = isset( $document_options['is_image'] ) && $document_options['is_image'];
+				}
+
 				$media_items_main[] = 
 					tainacan_get_the_media_component_slide(array(
+						'after_slide_metadata' => tainacan_get_the_media_item_actions( array(
+							'expand_html' => ( $open_lightbox_on_click && ! $document_is_image && ! $document_uses_cover ) ? tainacan_get_the_media_item_expand_control() : '',
+							'item_id' => $item_id,
+							'attachment_id' => ( $document_type === 'attachment' ) ? tainacan_get_the_document_raw( $item_id ) : 0,
+							'media_source' => 'document',
+							'media_type' => $document_mimetype,
+						) ),
 						'media_content' => $document_media_content,
 						'media_content_full' => $open_lightbox_on_click ?
 												(

--- a/src/classes/theme-helper/template-tags.php
+++ b/src/classes/theme-helper/template-tags.php
@@ -206,11 +206,13 @@ function tainacan_get_the_item_document_download_link($item_id = 0) {
 	$html = '';
 
 	if ( $link && $item->get_document_type() != 'text' && $item->get_document_type() != 'url' ) {
+		$label = __( 'Download', 'tainacan' );
 		$html = sprintf(
-			'<span class="tainacan-item-file-download"><a download="%1$s" href="%1$s" target="_blank" aria-label="%2$s"><span class="tainacan-item-file-download__label">%3$s</span></a></span>',
+			'<span class="tainacan-item-file-download"><a download="%1$s" href="%1$s" target="_blank" aria-label="%2$s" title="%3$s"><span class="tainacan-item-file-download__label">%4$s</span></a></span>',
 			esc_url( $link ),
 			esc_attr( __( 'Download the item document', 'tainacan' ) ),
-			esc_html( __( 'Download', 'tainacan' ) )
+			esc_attr( $label ),
+			esc_html( $label )
 		);
 	}
 
@@ -262,11 +264,13 @@ function tainacan_get_the_item_attachment_download_link($attachment_id) {
 	$html = '';
 
 	if ( $link ) {
+		$label = __( 'Download', 'tainacan' );
 		$html = sprintf(
-			'<span class="tainacan-item-file-download"><a download="%1$s" href="%1$s" aria-label="%2$s"><span class="tainacan-item-file-download__label">%3$s</span></a></span>',
+			'<span class="tainacan-item-file-download"><a download="%1$s" href="%1$s" aria-label="%2$s" title="%3$s"><span class="tainacan-item-file-download__label">%4$s</span></a></span>',
 			esc_url( $link ),
 			esc_attr( __( 'Download the item attachment', 'tainacan' ) ),
-			esc_html( __( 'Download', 'tainacan' ) )
+			esc_attr( $label ),
+			esc_html( $label )
 		);
 	}
 
@@ -293,6 +297,93 @@ function tainacan_get_the_item_attachment_download_link($attachment_id) {
  */
 function tainacan_the_item_attachment_download_link($attachment_id) {
 	return tainacan_get_the_item_attachment_download_link($attachment_id);
+}
+
+/**
+ * Return the item gallery Expand control as HTML.
+ *
+ * Opens PhotoSwipe at the current slide. Markup matches the Download control: a
+ * `.tainacan-media-item-expand` wrapper around a plain link so themes that style
+ * `a` (and `.tainacan-item-file-download`) can restyle both the same way.
+ *
+ * @return string The HTML expand control.
+ */
+function tainacan_get_the_media_item_expand_control() {
+	/* translators: Opens this media in the large gallery viewer. */
+	$label = __( 'Expand', 'tainacan' );
+	$html = sprintf(
+		'<span class="tainacan-media-item-expand"><a href="#" title="%1$s"><span class="tainacan-media-item-expand__label">%2$s</span></a></span>',
+		esc_attr( $label ),
+		esc_html( $label )
+	);
+
+	/**
+	 * Filters the item gallery Expand control HTML.
+	 *
+	 * @param string $html The HTML expand control.
+	 */
+	return apply_filters( 'tainacan_get_the_media_item_expand_control', $html );
+}
+
+/**
+ * Return a slide actions wrapper around Expand, Download, and similar controls.
+ *
+ * @param array $args {
+ *     Optional. Array of arguments.
+ *     @type string $expand_html    Expand control HTML, or empty. Default ''.
+ *     @type string $download_html  Download control HTML, or empty. Default ''.
+ *     @type int    $item_id        The item ID this slide belongs to. Default 0.
+ *     @type int    $attachment_id WP attachment ID when the slide is an attachment (item document or extra file). Default 0.
+ *     @type string $media_source   'document' or 'attachment'. Default ''.
+ *     @type string $media_type     MIME type or media type string. Default ''.
+ * }
+ * @return string The actions wrapper HTML, or empty string if there is nothing to show.
+ */
+function tainacan_get_the_media_item_actions( $args = array() ) {
+	$args = wp_parse_args(
+		$args,
+		array(
+			'expand_html'    => '',
+			'download_html'  => '',
+			'item_id'        => 0,
+			'attachment_id' => 0,
+			'media_source'   => '',
+			'media_type'     => '',
+		)
+	);
+
+	$inner = '';
+	if ( ! empty( $args['expand_html'] ) ) {
+		$inner .= $args['expand_html'];
+	}
+	if ( ! empty( $args['download_html'] ) ) {
+		$inner .= $args['download_html'];
+	}
+
+	/**
+	 * Filters the HTML inside the slide actions row.
+	 *
+	 * Runs even when Expand and Download are empty, so extra controls can still
+	 * create the row. The wrapper `.tainacan-media-item-actions` is added after
+	 * this filter if the result is not empty.
+	 *
+	 * @param string $html The inner actions HTML, or empty.
+	 * @param array  $args {
+	 *     @type string $expand_html    Expand control HTML, or empty.
+	 *     @type string $download_html  Download control HTML, or empty.
+	 *     @type int    $item_id        The item ID this slide belongs to.
+	 *     @type int    $attachment_id WP attachment ID, or 0.
+	 *     @type string $media_source   'document' or 'attachment'.
+	 *     @type string $media_type     MIME type or media type string.
+	 * }
+	 */
+	$inner = apply_filters( 'tainacan_get_the_media_item_actions', $inner, $args );
+
+	if ( $inner === '' ) {
+		return '';
+	}
+
+	return '<div class="tainacan-media-item-actions">' . $inner . '</div>';
 }
 
 /**
@@ -843,13 +934,15 @@ function tainacan_get_the_media_component_slide( $args = array() ) {
 			</div>
 		<?php endif; ?>
 
+		<?php if ( ! empty( $args['after_slide_metadata'] ) ) : ?>
+			<?php echo wp_kses( $args['after_slide_metadata'], wp_kses_allowed_html( 'tainacan_media_slide' ) ); ?>
+		<?php endif; ?>
+
 		<?php if ( !empty($args['media_content_full']) ) : ?>
 			<div class="media-full-content" style="display: none; position: absolute; visibility: hidden;">
 				<?php echo wp_kses($args['media_content_full'], wp_kses_allowed_html('tainacan_content')) ?>
 			</div>
 		<?php endif; ?>
-
-		<?php echo wp_kses_post($args['after_slide_metadata']) ?>
 
 	</div>
 

--- a/src/views/gutenberg-blocks/blocks/item-gallery/edit.js
+++ b/src/views/gutenberg-blocks/blocks/item-gallery/edit.js
@@ -161,7 +161,7 @@ export default function ({ attributes, setAttributes, isSelected, clientId }) {
                     />
                     <ToggleControl
                         label={__('Open lightbox on click', 'tainacan')}
-                        help={ __('Images and document covers open the large viewer on click. Video, audio and embedded files stay interactive; use Expand to open the gallery.', 'tainacan') }
+                        help={ __('Use Expand to open the large viewer for any media. Images and document covers also open it on click; video, audio and embedded files stay interactive.', 'tainacan') }
                         checked={ openLightboxOnClick }
                         onChange={ ( isChecked ) => {
                                 openLightboxOnClick = isChecked;

--- a/src/views/gutenberg-blocks/blocks/item-gallery/edit.js
+++ b/src/views/gutenberg-blocks/blocks/item-gallery/edit.js
@@ -161,6 +161,7 @@ export default function ({ attributes, setAttributes, isSelected, clientId }) {
                     />
                     <ToggleControl
                         label={__('Open lightbox on click', 'tainacan')}
+                        help={ __('Images and document covers open the large viewer on click. Video, audio and embedded files stay interactive; use Expand to open the gallery.', 'tainacan') }
                         checked={ openLightboxOnClick }
                         onChange={ ( isChecked ) => {
                                 openLightboxOnClick = isChecked;

--- a/src/views/gutenberg-blocks/blocks/item-gallery/style.scss
+++ b/src/views/gutenberg-blocks/blocks/item-gallery/style.scss
@@ -134,6 +134,7 @@
         margin: 0;
 
         &[data-pswp-uid]:not([data-pswp-uid='']) .tainacan-media-item .swiper-slide-content {
+            .tainacan-media-item-actions,
             .tainacan-item-file-download {
                 z-index: 99;
             }
@@ -143,6 +144,7 @@
             a {
                 cursor: zoom-in !important;
             }
+            .tainacan-media-item-actions a,
             .tainacan-item-file-download a,
             .swiper-slide-metadata a {
                 cursor: pointer !important;
@@ -304,6 +306,17 @@
         .twitter-tweet {
             margin-left: auto;
             margin-right: auto;
+        }
+
+        .tainacan-media-item-actions {
+            display: flex;
+            flex-wrap: wrap;
+            justify-content: center;
+            align-items: center;
+            gap: 0.75em;
+            position: relative;
+            z-index: 99;
+            margin-top: 0.5em;
         }
     }
 }

--- a/src/views/gutenberg-blocks/blocks/item-gallery/theme.js
+++ b/src/views/gutenberg-blocks/blocks/item-gallery/theme.js
@@ -346,6 +346,16 @@ tainacan_plugin.classes.TainacanMediaGallery = class TainacanMediaGallery {
             });
         });
 
+        /* Stops propagation of slide actions (Expand, Download) to avoid opening the gallery on them */
+        let carouselSlideActions = galleryElement.getElementsByClassName('tainacan-media-item-actions');
+        if (carouselSlideActions && carouselSlideActions.length) {
+            for (let i = 0; i < carouselSlideActions.length; i++) {
+                carouselSlideActions[i].addEventListener('click', function(e) {
+                    e.stopPropagation();
+                });
+            }
+        }
+
         /* Stops propagation of download button to avoid opening the gallery on it */
         let carouselDownloadButtons = galleryElement.getElementsByClassName('tainacan-item-file-download');
         if (carouselDownloadButtons && carouselDownloadButtons.length) {
@@ -355,6 +365,8 @@ tainacan_plugin.classes.TainacanMediaGallery = class TainacanMediaGallery {
                 });
             }
         }
+
+        this.setupLightboxExpandControls(galleryElement, items);
 
         /* Stops propagation inside links that are inside metatada */
         let carouselMetadataLinks = galleryElement.querySelectorAll('.swiper-slide-metadata a');
@@ -476,6 +488,8 @@ tainacan_plugin.classes.TainacanMediaGallery = class TainacanMediaGallery {
             return true;
         if (node.closest('.swiper-slide-metadata'))
             return true;
+        if (node.closest('.tainacan-media-item-actions'))
+            return true;
         if (node.closest('.tainacan-item-file-download'))
             return true;
         return false;
@@ -514,6 +528,8 @@ tainacan_plugin.classes.TainacanMediaGallery = class TainacanMediaGallery {
         for (let i = 0; i < allLinks.length; i++) {
             const link = allLinks[i];
             if (metadataElement && metadataElement.contains(link))
+                continue;
+            if (link.closest('.tainacan-media-item-actions'))
                 continue;
             if (link.closest('.tainacan-item-file-download'))
                 continue;
@@ -652,6 +668,31 @@ tainacan_plugin.classes.TainacanMediaGallery = class TainacanMediaGallery {
                         slide.dispatchEvent(clickEvent);
                     }
                 }
+            });
+        });
+    }
+
+    /**
+     * Expand opens PhotoSwipe at the slide index without stealing player clicks.
+     * @param {HTMLElement} galleryElement
+     * @param {Array} items Parsed PhotoSwipe items (same index as Swiper).
+     */
+    setupLightboxExpandControls(galleryElement, items) {
+        const self = this;
+        const expandControls = galleryElement.querySelectorAll('.tainacan-media-item-expand');
+
+        Array.prototype.forEach.call(expandControls, (expandControl) => {
+            expandControl.addEventListener('click', function(e) {
+                e.preventDefault();
+                e.stopPropagation();
+
+                if (!self.lightbox)
+                    return;
+
+                const slide = expandControl.closest('.tainacan-media-item');
+                const index = items.findIndex(anItem => anItem.el === slide);
+                if (index >= 0)
+                    self.lightbox.loadAndOpen(index);
             });
         });
     }

--- a/src/views/gutenberg-blocks/blocks/items-gallery/edit.js
+++ b/src/views/gutenberg-blocks/blocks/items-gallery/edit.js
@@ -363,7 +363,7 @@ export default function ({ attributes, setAttributes, isSelected, clientId }) {
                     />
                     <ToggleControl
                         label={__('Open lightbox on click', 'tainacan')}
-                        help={ __('Images and document covers open the large viewer on click. Video, audio and embedded files stay interactive; use Expand to open the gallery.', 'tainacan') }
+                        help={ __('Use Expand to open the large viewer for any media. Images and document covers also open it on click; video, audio and embedded files stay interactive.', 'tainacan') }
                         checked={ openLightboxOnClick }
                         onChange={ ( isChecked ) => {
                                 openLightboxOnClick = isChecked;

--- a/src/views/gutenberg-blocks/blocks/items-gallery/edit.js
+++ b/src/views/gutenberg-blocks/blocks/items-gallery/edit.js
@@ -363,6 +363,7 @@ export default function ({ attributes, setAttributes, isSelected, clientId }) {
                     />
                     <ToggleControl
                         label={__('Open lightbox on click', 'tainacan')}
+                        help={ __('Images and document covers open the large viewer on click. Video, audio and embedded files stay interactive; use Expand to open the gallery.', 'tainacan') }
                         checked={ openLightboxOnClick }
                         onChange={ ( isChecked ) => {
                                 openLightboxOnClick = isChecked;


### PR DESCRIPTION
## Description

After #1148, images and document covers still open PhotoSwipe on click, while video, audio, and embeds stay interactive. Mixed galleries still needed a way to open the large viewer **at the current slide**.

This PR adds an **Expand** control next to Download, in a shared slide-actions row:

- Visible text **Expand** (translator comment: *Opens this media in the large gallery viewer.*). Plugin CSS is layout only so themes can restyle it like Download.
- Markup matches Download: `.tainacan-media-item-expand` around a plain `<a>`, wrapped with Download in `.tainacan-media-item-actions` (sibling of the slide metadata).
- Shown for **every media type** when the lightbox is on (including images and covers). Click-to-zoom on images is unchanged; players and iframes keep the first click.
- Clicking Expand opens PhotoSwipe at that slide and does not bubble to the lightbox handler (`stopPropagation`, same as Download).
- Themes and plugins can replace or extend the row via `tainacan_get_the_media_item_expand_control` and `tainacan_get_the_media_item_actions`.

Download links also get a `title` matching the visible label. The Item Gallery and Items Gallery block inspector help text now describe Expand vs click-to-open.

This is the slot #1150 (“Visit the page”) and theme customizers can hook into. No `block.json` / `save.js` change.

## Related issue

Closes #1149

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would change existing behavior)
- [ ] Refactor / technical debt (no user-facing change)
- [ ] Documentation

## Checklist

- [x] My code follows the project's coding standards (ESLint / PHPCS)
- [x] I have tested my changes locally
- [ ] I have added or updated tests when applicable
- [ ] If I changed a Gutenberg block's `block.json` or `save.js`, I updated the corresponding `deprecated.js`
- [ ] I have updated the documentation when needed
- [ ] For UI changes, I have added screenshots or a screen recording below